### PR TITLE
fix: prevent horizontal overflow on mobile

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -89,7 +89,7 @@ export default function Home() {
       <section className="border-t border-border">
         <div className="max-w-5xl mx-auto px-6 py-24">
           <div className="grid lg:grid-cols-2 gap-12">
-            <div>
+            <div className="min-w-0">
               <h2 className="text-2xl font-semibold mb-4">
                 Define your catalog
               </h2>
@@ -121,7 +121,7 @@ export const catalog = createCatalog({
   },
 });`}</Code>
             </div>
-            <div>
+            <div className="min-w-0">
               <h2 className="text-2xl font-semibold mb-4">AI generates JSON</h2>
               <p className="text-muted-foreground mb-6">
                 Constrained output that your components render natively.

--- a/apps/web/components/code.tsx
+++ b/apps/web/components/code.tsx
@@ -151,7 +151,7 @@ export async function Code({ children, lang = "typescript" }: CodeProps) {
   });
 
   return (
-    <div className="group relative my-6 rounded-lg border border-border bg-neutral-100 dark:bg-[#0a0a0a] text-sm font-mono overflow-hidden">
+    <div className="group relative my-6 rounded-lg border border-border bg-neutral-100 dark:bg-[#0a0a0a] text-sm font-mono overflow-hidden max-w-full">
       <div className="absolute top-3 right-3 z-10">
         <CopyButton
           text={children.trim()}

--- a/apps/web/components/demo.tsx
+++ b/apps/web/components/demo.tsx
@@ -403,7 +403,7 @@ export function Demo() {
 
       <div className="grid lg:grid-cols-2 gap-4">
         {/* Tabbed code/stream/json panel */}
-        <div>
+        <div className="min-w-0">
           <div className="flex items-center gap-4 mb-2 h-6">
             {(["json", "stream", "code"] as const).map((tab) => (
               <button
@@ -448,7 +448,7 @@ export function Demo() {
         </div>
 
         {/* Rendered output using json-render */}
-        <div>
+        <div className="min-w-0">
           <div className="flex items-center justify-between mb-2 h-6">
             <div className="text-xs text-muted-foreground font-mono">
               render


### PR DESCRIPTION
## Problem

On mobile devices, the page has horizontal scroll overflow, causing a poor user experience. This is especially noticeable on the homepage where code blocks and grid layouts extend beyond the viewport width.

![Screenshot](https://github.com/user-attachments/assets/caab3e7d-897e-4680-a4f7-8a9226715f00)

## Root Cause

1. CSS Grid/Flexbox children default to `min-width: auto`, preventing them from shrinking below their content size
2. Code blocks with long lines weren't constrained to their parent container width

## Solution

- Add `min-w-0` to grid children in the demo and homepage code example sections, allowing them to shrink properly
- Add `max-w-full` to code block containers to respect parent boundaries