### PR TITLE
Fix dark mode readability for Alert component

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -45,8 +45,8 @@
   --accent-foreground: oklch(0.98 0 0);
   --destructive: oklch(0.65 0.2 25);
   --destructive-foreground: oklch(0.98 0 0);
-  --border: oklch(0.2 0 0);
-  --input: oklch(0.2 0 0);
+  --border: oklch(0.25 0 0);
+  --input: oklch(0.25 0 0);
   --ring: oklch(0.4 0 0);
 }
 

--- a/apps/web/components/demo/alert.tsx
+++ b/apps/web/components/demo/alert.tsx
@@ -9,12 +9,12 @@ export function Alert({ element }: ComponentRenderProps) {
   const alertType = props.type as string;
   const alertClass =
     alertType === "success"
-      ? "bg-green-50 border-green-200"
+      ? "bg-green-50 dark:bg-green-950 border-green-200 dark:border-green-800 text-green-900 dark:text-green-100"
       : alertType === "warning"
-        ? "bg-yellow-50 border-yellow-200"
+        ? "bg-yellow-50 dark:bg-yellow-950 border-yellow-200 dark:border-yellow-800 text-yellow-900 dark:text-yellow-100"
         : alertType === "error"
-          ? "bg-red-50 border-red-200"
-          : "bg-blue-50 border-blue-200";
+          ? "bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800 text-red-900 dark:text-red-100"
+          : "bg-blue-50 dark:bg-blue-950 border-blue-200 dark:border-blue-800 text-blue-900 dark:text-blue-100";
 
   return (
     <div


### PR DESCRIPTION
### 🎨 Dark Mode Alert Improvements

- Fixed dark mode contrast issues in generated **Alert** components where text was nearly invisible on lighter backgrounds.
- Made each alert variant fully **theme-aware**, with explicit light/dark background, border, and text colors.
- Slightly increased dark-mode `--border` and `--input` lightness in `globals.css` to improve card and input separation—without impacting light mode.

**Before changes (Image 1):**  
- Alert text had poor contrast in dark mode, making it hard to read on lighter backgrounds.

<img width="1764" height="782" alt="Before changes – dark mode alert contrast issue" src="https://github.com/user-attachments/assets/c6798bb4-932f-44ad-9c3b-2905d82c1442" />

**After changes (Image 2):**  
- Improved contrast with theme-aware alert variants.
- Alerts are now clearly readable and visually consistent across themes.

<img width="1700" height="795" alt="After changes – improved dark mode alert contrast" src="https://github.com/user-attachments/assets/f496738b-cfff-42a3-bcb8-63e3dc1c27fa" />
