### PR TITLE
fix: update AI Gateway API key link

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,4 @@
 # AI Gateway API Key (required for /api/generate endpoint)
 # Uses Vercel AI Gateway - automatically authenticated when deployed on Vercel
-# For local development, get your key from https://vercel.com/docs/ai/ai-sdk
+# For local development, get your key from https://vercel.com/ai-gateway
 AI_GATEWAY_API_KEY=

--- a/examples/dashboard/.env.example
+++ b/examples/dashboard/.env.example
@@ -1,4 +1,4 @@
 # AI Gateway API Key (required for /api/generate endpoint)
 # Uses Vercel AI Gateway - automatically authenticated when deployed on Vercel
-# For local development, get your key from https://vercel.com/docs/ai/ai-sdk
+# For local development, get your key from https://vercel.com/ai-gateway
 AI_GATEWAY_API_KEY=


### PR DESCRIPTION
I noticed that the current link (https://vercel.com/docs/ai/ai-sdk) returns a 404.

<img width="1624" height="971" alt="image" src="https://github.com/user-attachments/assets/d1f9485f-ac09-4357-9013-0588f6492885" />

So I looked for where it's possible to get the AI Gateway API key and found https://vercel.com/ai-gateway