### PR TITLE
fix: improve Rating contrast in dark mode

### DIFF
--- a/apps/web/components/demo/rating.tsx
+++ b/apps/web/components/demo/rating.tsx
@@ -20,7 +20,7 @@ export function Rating({ element }: ComponentRenderProps) {
         {Array.from({ length: maxRating }).map((_, i) => (
           <span
             key={i}
-            className={`text-sm ${i < ratingValue ? "text-yellow-400" : "text-muted"}`}
+            className={`text-sm ${i < ratingValue ? "text-yellow-400" : "text-foreground/30"}`}
           >
             *
           </span>


### PR DESCRIPTION
### Summary
Fixes an issue where rating stars generated in feedback forms were visible in light mode but nearly invisible in dark mode due to insufficient contrast.

Since this prompt is suggested to first-time users, the generated UI should remain readable and consistent across both light and dark themes.

---

### Before
- Light mode: rating stars render as expected
- Dark mode: stars have very low contrast and are difficult to see

### After
- Dark mode: rating stars are clearly visible with theme-aware colors
- Behavior remains unchanged in light mode
- Unfilled stars now use `text-foreground/30`, keeping them muted while remaining readable in dark mode


---

### Screenshots
- Before (Light mode)

<img width="1492" height="875" alt="Screenshot from 2026-01-18 08-53-37" src="https://github.com/user-attachments/assets/35fb33c5-60d4-45b6-bf90-89e78272d101" />

- Before (Dark mode)

<img width="1492" height="875" alt="Screenshot from 2026-01-18 08-54-33" src="https://github.com/user-attachments/assets/2573061a-f8ff-4dd3-96ea-d790a358d2d5" />

- After (Dark mode)

<img width="1492" height="875" alt="Screenshot from 2026-01-18 08-55-31" src="https://github.com/user-attachments/assets/f40b5a6c-c12a-45a4-a4d7-772350440a73" />

