### PR TITLE
Fix JSONL patch format in /docs and add API route documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ function Dashboard() {
           placeholder="Create a revenue dashboard..."
           onKeyDown={(e) => e.key === 'Enter' && send(e.target.value)}
         />
-        <Renderer tree={tree} components={registry} />
+        <Renderer tree={tree} registry={registry} />
       </ActionProvider>
     </DataProvider>
   );

--- a/apps/web/app/docs/streaming/page.tsx
+++ b/apps/web/app/docs/streaming/page.tsx
@@ -17,9 +17,10 @@ export default function StreamingPage() {
         json-render uses JSONL (JSON Lines) streaming. As AI generates, each
         line represents a patch operation:
       </p>
-      <Code lang="json">{`{"op":"set","path":"/root","value":{"key":"root","type":"Card","props":{"title":"Dashboard"}}}
-{"op":"add","path":"/root/children","value":{"key":"metric-1","type":"Metric","props":{"label":"Revenue"}}}
-{"op":"add","path":"/root/children","value":{"key":"metric-2","type":"Metric","props":{"label":"Users"}}}`}</Code>
+      <Code lang="json">{`{"op":"set","path":"/root","value":"dashboard"}
+{"op":"set","path":"/elements/dashboard","value":{"key":"dashboard","type":"Card","props":{"title":"Dashboard"},"children":["metric-1","metric-2"]}}
+{"op":"set","path":"/elements/metric-1","value":{"key":"metric-1","type":"Metric","props":{"label":"Revenue"}}}
+{"op":"set","path":"/elements/metric-2","value":{"key":"metric-2","type":"Metric","props":{"label":"Users"}}}`}</Code>
 
       <h2 className="text-xl font-semibold mt-12 mb-4">useUIStream Hook</h2>
       <p className="text-sm text-muted-foreground mb-4">


### PR DESCRIPTION
## Issue

1. JSONL patch format is not documented - structure expected by `useUIStream`'s internal `applyPatch` function not specified in the README or docs.
2. `apps/web/app/docs/streaming/page.tsx` shows `/root/children` paths which silently fail, as the applyPatch function at packages/react/src/hooks.ts only supports `/root` and `/elements/{key}` paths.
4. Renderer uses wrong prop name - README example shows `components={registry}` but should be `registry={registry}`.

Based on `packages/react/src/hooks.ts`:
- The patch format uses `/root` and `/elements/{key}` paths, not JSON Pointer paths like `/children/-`
- `send(prompt)` takes a string directly, not `{ prompt }`
- The hook returns `isStreaming` (not `status`) and `clear()` (not `reset()`)

## Changes
**1. README.md**:
Added "API Route Integration" section with:
- JSONL patch format specification
- `useUIStream` hook reference
- Complete API route example (Next.js + Vercel AI SDK)
- Context provider for `Renderer` component
- Fixed `Renderer` prop: `components` → `registry`

**2. apps/web/app/docs/streaming/page.tsx**:
- Fixed incorrect path: `/root/children` → `/elements/{key}` with `children` array