### PR TITLE
fix: fix button actions on dashboard example

### DIFF
--- a/examples/dashboard/app/api/generate/route.ts
+++ b/examples/dashboard/app/api/generate/route.ts
@@ -15,7 +15,7 @@ COMPONENT DETAILS:
 - Metric: { label: string, valuePath: string, format?: "number"|"currency"|"percent", trend?: "up"|"down"|"neutral", trendValue?: string }
 - Chart: { type: "bar"|"line"|"pie"|"area", dataPath: string, title?: string, height?: number }
 - Table: { dataPath: string, columns: [{ key: string, label: string, format?: "text"|"currency"|"date"|"badge" }] }
-- Button: { label: string, action: string, variant?: "primary"|"secondary"|"danger"|"ghost" }
+- Button: { label: string, action: "export_report"|"refresh_data"|"view_details"|"apply_filter", variant?: "primary"|"secondary"|"danger"|"ghost" }
 - Heading: { text: string, level?: "h1"|"h2"|"h3"|"h4" }
 - Text: { content: string, variant?: "body"|"caption"|"label", color?: "default"|"muted"|"success"|"warning"|"danger" }
 - Badge: { text: string, variant?: "default"|"success"|"warning"|"danger"|"info" }

--- a/examples/dashboard/components/ui/button.tsx
+++ b/examples/dashboard/components/ui/button.tsx
@@ -7,7 +7,7 @@ export function Button({ element, onAction, loading }: ComponentRenderProps) {
   const { label, variant, action, disabled } = element.props as {
     label: string;
     variant?: string | null;
-    action: { name: string };
+    action: string;
     disabled?: boolean | null;
   };
 
@@ -28,7 +28,7 @@ export function Button({ element, onAction, loading }: ComponentRenderProps) {
 
   return (
     <button
-      onClick={() => !disabled && action && onAction?.(action)}
+      onClick={() => !disabled && action && onAction?.({ name: action })}
       disabled={!!disabled || loading}
       style={{
         padding: "8px 16px",


### PR DESCRIPTION
While playing around with the dashboard example locally, I noticed that none of the button actions were working. Whenever a button was clicked, the following error would appear: `No handler registered for action: undefined`.

The reason was that `onAction` being called with `action` as argument, but it should have been an object with the `name` property instead: `onAction?.(action) → onAction?.({name: action})`.

Also on the "COMPONENT DETAILS" part of the system prompt, I changed `string` for an enum with all the actions defined on the action handlers. That way the LLM would always return one of the defined strings instead of something such as "export_data" (that happened to me when my prompt mentioned only "export button" instead of "export report button", which is not defined in the handlers).

<img width="994" height="973" alt="image" src="https://github.com/user-attachments/assets/92cd3b73-0471-41aa-8671-73ae4a921b81" />
