### PR TITLE
chore: remove unused imports on `packages/react/src/renderer.tsx`

### DIFF
--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { type ComponentType, type ReactNode, useMemo } from "react";
+import { type ComponentType, type ReactNode } from "react";
 import type {
   UIElement,
   UITree,
@@ -10,7 +10,6 @@ import type {
 } from "@json-render/core";
 import { useIsVisible } from "./contexts/visibility";
 import { useActions } from "./contexts/actions";
-import { useData } from "./contexts/data";
 
 /**
  * Props passed to component renderers


### PR DESCRIPTION
Noticed there were some unused imports on packages/react/src/renderer.tsx and I removed them. Before manually removing, I tried to see if `turbo lint` would spot them, but it didn't.