### PR TITLE
fix: use getByPath instead of custom value creation

### DIFF
--- a/packages/react/src/contexts/validation.tsx
+++ b/packages/react/src/contexts/validation.tsx
@@ -13,6 +13,7 @@ import {
   type ValidationConfig,
   type ValidationFunction,
   type ValidationResult,
+  getByPath,
 } from "@json-render/core";
 import { useData } from "./data";
 
@@ -83,7 +84,7 @@ export function ValidationProvider({
 
   const validate = useCallback(
     (path: string, config: ValidationConfig): ValidationResult => {
-      const value = data[path.split("/").filter(Boolean).join(".")];
+      const value = getByPath(data, path);
       const result = runValidation(config, {
         value,
         dataModel: data,


### PR DESCRIPTION
Validation didn't trigger correctly.

When I've used validation it always triggered all available checks and set all of them to not passing the conditions.
This seems to fix the issue in a minimal example.

cc @ctate 