### PR TITLE
Fix LLM hallucinations by dynamically generating prompt examples from catalog

### DIFF
--- a/apps/web/lib/render/catalog.ts
+++ b/apps/web/lib/render/catalog.ts
@@ -24,6 +24,7 @@ export const playgroundCatalog = defineCatalog(schema, {
       slots: ["default"],
       description:
         "Container card for content sections. Use for forms/content boxes, NOT for page headers.",
+      example: { title: "Overview", description: "Your account summary" },
     },
 
     Stack: {
@@ -37,6 +38,7 @@ export const playgroundCatalog = defineCatalog(schema, {
       }),
       slots: ["default"],
       description: "Flex container for layouts",
+      example: { direction: "vertical", gap: "md" },
     },
 
     Grid: {
@@ -46,6 +48,7 @@ export const playgroundCatalog = defineCatalog(schema, {
       }),
       slots: ["default"],
       description: "Grid layout (1-6 columns)",
+      example: { columns: 3, gap: "md" },
     },
 
     Separator: {
@@ -137,6 +140,13 @@ export const playgroundCatalog = defineCatalog(schema, {
       }),
       description:
         'Data table. columns: header labels. rows: 2D array of cell strings, e.g. [["Alice","admin"],["Bob","user"]].',
+      example: {
+        columns: ["Name", "Role"],
+        rows: [
+          ["Alice", "Admin"],
+          ["Bob", "User"],
+        ],
+      },
     },
 
     Heading: {
@@ -145,6 +155,7 @@ export const playgroundCatalog = defineCatalog(schema, {
         level: z.enum(["h1", "h2", "h3", "h4"]).nullable(),
       }),
       description: "Heading text (h1-h4)",
+      example: { text: "Welcome", level: "h1" },
     },
 
     Text: {
@@ -155,6 +166,7 @@ export const playgroundCatalog = defineCatalog(schema, {
           .nullable(),
       }),
       description: "Paragraph text",
+      example: { text: "Hello, world!" },
     },
 
     Image: {
@@ -173,6 +185,7 @@ export const playgroundCatalog = defineCatalog(schema, {
         size: z.enum(["sm", "md", "lg"]).nullable(),
       }),
       description: "User avatar with fallback initials",
+      example: { name: "Jane Doe", size: "md" },
     },
 
     Badge: {
@@ -181,6 +194,7 @@ export const playgroundCatalog = defineCatalog(schema, {
         variant: z.enum(["default", "success", "warning", "danger"]).nullable(),
       }),
       description: "Status badge",
+      example: { text: "Active", variant: "success" },
     },
 
     Alert: {
@@ -190,6 +204,11 @@ export const playgroundCatalog = defineCatalog(schema, {
         type: z.enum(["info", "success", "warning", "error"]).nullable(),
       }),
       description: "Alert banner",
+      example: {
+        title: "Note",
+        message: "Your changes have been saved.",
+        type: "success",
+      },
     },
 
     Progress: {
@@ -199,6 +218,7 @@ export const playgroundCatalog = defineCatalog(schema, {
         label: z.string().nullable(),
       }),
       description: "Progress bar (value 0-100)",
+      example: { value: 65, max: 100, label: "Upload progress" },
     },
 
     Skeleton: {
@@ -281,6 +301,12 @@ export const playgroundCatalog = defineCatalog(schema, {
       }),
       events: ["submit", "focus", "blur"],
       description: "Text input field. Use statePath for two-way binding.",
+      example: {
+        label: "Email",
+        name: "email",
+        type: "email",
+        placeholder: "you@example.com",
+      },
     },
 
     Textarea: {
@@ -360,6 +386,7 @@ export const playgroundCatalog = defineCatalog(schema, {
       }),
       events: ["press"],
       description: "Clickable button. Bind on.press for handler.",
+      example: { label: "Submit", variant: "primary" },
     },
 
     Link: {

--- a/examples/dashboard/lib/render/catalog.ts
+++ b/examples/dashboard/lib/render/catalog.ts
@@ -18,6 +18,7 @@ export const dashboardCatalog = defineCatalog(schema, {
       }),
       slots: ["default"],
       description: "Flex layout container",
+      example: { direction: "vertical", gap: "md" },
     },
 
     Accordion: {
@@ -50,6 +51,7 @@ export const dashboardCatalog = defineCatalog(schema, {
       }),
       description:
         "Clickable button. Use actionParams to pass parameters to the action (e.g., { limit: 5, sort: 'newest' })",
+      example: { label: "Save", variant: "default", action: "formSubmit" },
     },
 
     Input: {
@@ -60,6 +62,12 @@ export const dashboardCatalog = defineCatalog(schema, {
         type: z.enum(["text", "email", "password", "number", "tel"]).nullable(),
       }),
       description: "Text input field",
+      example: {
+        label: "Email",
+        valuePath: "/form/email",
+        placeholder: "you@example.com",
+        type: "email",
+      },
     },
 
     Form: {
@@ -81,6 +89,7 @@ export const dashboardCatalog = defineCatalog(schema, {
           .nullable(),
       }),
       description: "Status badge",
+      example: { text: "Active", variant: "default" },
     },
 
     Alert: {
@@ -304,6 +313,13 @@ export const dashboardCatalog = defineCatalog(schema, {
         emptyMessage: z.string().nullable(),
       }),
       description: "Data table with optional row actions (delete, edit, etc.)",
+      example: {
+        statePath: "/customers/data",
+        columns: [
+          { key: "name", label: "Name" },
+          { key: "email", label: "Email" },
+        ],
+      },
     },
 
     // Typography
@@ -313,6 +329,7 @@ export const dashboardCatalog = defineCatalog(schema, {
         level: z.enum(["h1", "h2", "h3", "h4"]).nullable(),
       }),
       description: "Section heading",
+      example: { text: "Dashboard", level: "h1" },
     },
 
     Text: {
@@ -321,6 +338,7 @@ export const dashboardCatalog = defineCatalog(schema, {
         muted: z.boolean().nullable(),
       }),
       description: "Text content",
+      example: { content: "Welcome back! Here is your overview." },
     },
 
     // Charts

--- a/examples/react-native/lib/render/catalog.ts
+++ b/examples/react-native/lib/render/catalog.ts
@@ -47,6 +47,7 @@ export const catalog = defineCatalog(schema, {
       slots: [],
       description:
         "Icon display using Ionicons. Use for action buttons, navigation items, and indicators. ALWAYS use this instead of emoji characters for UI icons. Use Ionicons naming convention (e.g. heart, heart-outline, chatbubble-outline, share-social-outline).",
+      example: { name: "heart-outline", size: 24, color: "#007AFF" },
     },
   },
   actions: standardActionDefinitions,

--- a/examples/stripe-app/src/lib/render/catalog.ts
+++ b/examples/stripe-app/src/lib/render/catalog.ts
@@ -26,6 +26,7 @@ export const stripeCatalog = defineCatalog(schema, {
       }),
       description:
         "Flex layout container for arranging children horizontally or vertically with configurable gap and alignment",
+      example: { direction: "vertical", gap: "medium" },
     },
 
     Inline: {
@@ -71,6 +72,7 @@ export const stripeCatalog = defineCatalog(schema, {
           .default("large"),
       }),
       description: "Display a heading/title text with configurable size",
+      example: { text: "Overview", size: "large" },
     },
 
     Text: {
@@ -94,6 +96,7 @@ export const stripeCatalog = defineCatalog(schema, {
       }),
       description:
         "Display body text with configurable color, size, and weight",
+      example: { content: "Payment received successfully.", color: "primary" },
     },
 
     // =========================================================================
@@ -111,6 +114,13 @@ export const stripeCatalog = defineCatalog(schema, {
       }),
       description:
         "Display a key metric with label, value, and optional trend indicator for KPIs",
+      example: {
+        label: "Revenue",
+        value: "$12,450",
+        change: "+8.2%",
+        changeType: "positive",
+        format: "currency",
+      },
     },
 
     Badge: {
@@ -128,6 +138,7 @@ export const stripeCatalog = defineCatalog(schema, {
           .default("neutral"),
       }),
       description: "Status badge indicator with configurable color type",
+      example: { label: "Active", type: "positive" },
     },
 
     Icon: {
@@ -284,6 +295,12 @@ export const stripeCatalog = defineCatalog(schema, {
         required: z.boolean().nullable(),
       }),
       description: "Text input field with label, validation, and data binding",
+      example: {
+        label: "Email",
+        placeholder: "customer@example.com",
+        valuePath: "/form/email",
+        type: "email",
+      },
     },
 
     TextArea: {
@@ -379,6 +396,11 @@ export const stripeCatalog = defineCatalog(schema, {
       }),
       description:
         "Action button with configurable style, size, and action handling",
+      example: {
+        label: "View Details",
+        action: "viewCustomer",
+        type: "primary",
+      },
     },
 
     ButtonGroup: {
@@ -451,6 +473,14 @@ export const stripeCatalog = defineCatalog(schema, {
       }),
       description:
         "Data table with configurable columns and optional row actions",
+      example: {
+        title: "Recent Payments",
+        statePath: "/payments/data",
+        columns: [
+          { key: "amount", label: "Amount" },
+          { key: "status", label: "Status" },
+        ],
+      },
     },
 
     // =========================================================================
@@ -465,6 +495,11 @@ export const stripeCatalog = defineCatalog(schema, {
       }),
       description:
         "Card displaying customer information with name, email, and status",
+      example: {
+        name: "Jane Smith",
+        email: "jane@example.com",
+        status: "active",
+      },
     },
 
     PaymentCard: {

--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -22,6 +22,8 @@ export interface ComponentDefinition<
   hasChildren?: boolean;
   /** Description for AI generation */
   description?: string;
+  /** Example prop values used in prompt examples (auto-generated from Zod schema if omitted) */
+  example?: Record<string, unknown>;
 }
 
 /**

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -551,19 +551,71 @@ function generatePrompt<TDef extends SchemaDefinition, TCatalog>(
   lines.push("Example output (each line is a separate JSON object):");
   lines.push("");
 
-  // Build example using actual catalog component names to avoid hallucinations
+  // Build example using actual catalog component names and props to avoid hallucinations
+  const allComponents = (catalog.data as Record<string, unknown>).components as
+    | Record<string, CatalogComponentDef>
+    | undefined;
   const cn = catalog.componentNames;
   const comp1 = cn[0] || "Component";
   const comp2 = cn.length > 1 ? cn[1]! : comp1;
+  const comp1Def = allComponents?.[comp1];
+  const comp2Def = allComponents?.[comp2];
+  const comp1Props = comp1Def ? getExampleProps(comp1Def) : {};
+  const comp2Props = comp2Def ? getExampleProps(comp2Def) : {};
 
-  lines.push(`{"op":"add","path":"/root","value":"main"}
-{"op":"add","path":"/elements/main","value":{"type":"${comp1}","props":{},"children":["title","list"]}}
-{"op":"add","path":"/elements/title","value":{"type":"${comp2}","props":{},"children":[]}}
-{"op":"add","path":"/elements/list","value":{"type":"${comp1}","props":{},"repeat":{"path":"/items","key":"id"},"children":["item"]}}
-{"op":"add","path":"/elements/item","value":{"type":"${comp2}","props":{"text":{"$path":"$item/title"}},"children":[]}}
-{"op":"add","path":"/state/items","value":[]}
-{"op":"add","path":"/state/items/0","value":{"id":"1","title":"First Item"}}
-{"op":"add","path":"/state/items/1","value":{"id":"2","title":"Second Item"}}
+  // Find a string prop on comp2 to demonstrate $path dynamic bindings
+  const dynamicPropName = comp2Def?.props
+    ? findFirstStringProp(comp2Def.props)
+    : null;
+  const dynamicProps = dynamicPropName
+    ? { ...comp2Props, [dynamicPropName]: { $path: "$item/title" } }
+    : comp2Props;
+
+  const exampleOutput = [
+    JSON.stringify({ op: "add", path: "/root", value: "main" }),
+    JSON.stringify({
+      op: "add",
+      path: "/elements/main",
+      value: {
+        type: comp1,
+        props: comp1Props,
+        children: ["child-1", "list"],
+      },
+    }),
+    JSON.stringify({
+      op: "add",
+      path: "/elements/child-1",
+      value: { type: comp2, props: comp2Props, children: [] },
+    }),
+    JSON.stringify({
+      op: "add",
+      path: "/elements/list",
+      value: {
+        type: comp1,
+        props: comp1Props,
+        repeat: { path: "/items", key: "id" },
+        children: ["item"],
+      },
+    }),
+    JSON.stringify({
+      op: "add",
+      path: "/elements/item",
+      value: { type: comp2, props: dynamicProps, children: [] },
+    }),
+    JSON.stringify({ op: "add", path: "/state/items", value: [] }),
+    JSON.stringify({
+      op: "add",
+      path: "/state/items/0",
+      value: { id: "1", title: "First Item" },
+    }),
+    JSON.stringify({
+      op: "add",
+      path: "/state/items/1",
+      value: { id: "2", title: "Second Item" },
+    }),
+  ].join("\n");
+
+  lines.push(`${exampleOutput}
 
 Note: state patches appear right after the elements that use them, so the UI fills in as it streams. ONLY use component types from the AVAILABLE COMPONENTS list below.`);
   lines.push("");
@@ -606,7 +658,7 @@ Note: state patches appear right after the elements that use them, so the UI fil
     'The element itself renders once (as the container), and its children are expanded once per array item. "path" is the state array path. "key" is an optional field name on each item for stable React keys.',
   );
   lines.push(
-    `Example: { "type": "${comp1}", "props": {}, "repeat": { "path": "/todos", "key": "id" }, "children": ["todo-item"] }`,
+    `Example: ${JSON.stringify({ type: comp1, props: comp1Props, repeat: { path: "/todos", key: "id" }, children: ["todo-item"] })}`,
   );
   lines.push(
     'Inside children of a repeated element, use "$item/field" for per-item paths: statePath:"$item/completed", { "$path": "$item/title" }. Use "$index" for the current array index.',
@@ -643,18 +695,8 @@ Note: state patches appear right after the elements that use them, so the UI fil
   );
   lines.push("");
 
-  // Components section
-  const components = (catalog.data as Record<string, unknown>).components as
-    | Record<
-        string,
-        {
-          props?: z.ZodType;
-          description?: string;
-          slots?: string[];
-          events?: string[];
-        }
-      >
-    | undefined;
+  // Components section — reuse the typed reference from example generation
+  const components = allComponents;
 
   if (components) {
     lines.push(`AVAILABLE COMPONENTS (${catalog.componentNames.length}):`);
@@ -699,7 +741,7 @@ Note: state patches appear right after the elements that use them, so the UI fil
   lines.push("");
   lines.push("Example:");
   lines.push(
-    `  {"type":"${comp1}","props":{},"on":{"press":{"action":"setState","params":{"path":"/saved","value":true}}},"children":[]}`,
+    `  ${JSON.stringify({ type: comp1, props: comp1Props, on: { press: { action: "setState", params: { path: "/saved", value: true } } }, children: [] })}`,
   );
   lines.push("");
   lines.push(
@@ -716,7 +758,7 @@ Note: state patches appear right after the elements that use them, so the UI fil
     "Elements can have an optional `visible` field to conditionally show/hide based on data state. IMPORTANT: `visible` is a top-level field on the element object (sibling of type/props/children), NOT inside props.",
   );
   lines.push(
-    `Correct: {"type":"${comp1}","props":{},"visible":{"eq":[{"path":"/tab"},"home"]},"children":[...]}`,
+    `Correct: ${JSON.stringify({ type: comp1, props: comp1Props, visible: { eq: [{ path: "/tab" }, "home"] }, children: ["..."] })}`,
   );
   lines.push(
     '- `{ "eq": [{ "path": "/statePath" }, "value"] }` - visible when state at path equals value',
@@ -785,6 +827,169 @@ Note: state patches appear right after the elements that use them, so the UI fil
 
   return lines.join("\n");
 }
+
+// =============================================================================
+// Example Value Generation from Zod Schemas
+// =============================================================================
+
+/**
+ * Component definition shape as it appears in catalog data
+ */
+interface CatalogComponentDef {
+  props?: z.ZodType;
+  description?: string;
+  slots?: string[];
+  events?: string[];
+  example?: Record<string, unknown>;
+}
+
+/**
+ * Get example props for a catalog component.
+ * Uses the explicit `example` field if provided, otherwise generates from Zod schema.
+ */
+function getExampleProps(def: CatalogComponentDef): Record<string, unknown> {
+  if (def.example && Object.keys(def.example).length > 0) {
+    return def.example;
+  }
+  if (def.props) {
+    return generateExamplePropsFromZod(def.props);
+  }
+  return {};
+}
+
+/**
+ * Generate example prop values from a Zod object schema.
+ * Only includes required fields to keep examples concise.
+ */
+function generateExamplePropsFromZod(
+  schema: z.ZodType,
+): Record<string, unknown> {
+  if (!schema || !schema._def) return {};
+  const def = schema._def as unknown as Record<string, unknown>;
+  const typeName = getZodTypeName(schema);
+
+  if (typeName !== "ZodObject" && typeName !== "object") return {};
+
+  const shape =
+    typeof def.shape === "function"
+      ? (def.shape as () => Record<string, z.ZodType>)()
+      : (def.shape as Record<string, z.ZodType>);
+  if (!shape) return {};
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(shape)) {
+    const innerTypeName = getZodTypeName(value);
+    // Skip optional props to keep examples concise
+    if (
+      innerTypeName === "ZodOptional" ||
+      innerTypeName === "optional" ||
+      innerTypeName === "ZodNullable" ||
+      innerTypeName === "nullable"
+    ) {
+      continue;
+    }
+    result[key] = generateExampleValue(value);
+  }
+  return result;
+}
+
+/**
+ * Generate a single example value from a Zod type.
+ */
+function generateExampleValue(schema: z.ZodType): unknown {
+  if (!schema || !schema._def) return "...";
+  const def = schema._def as unknown as Record<string, unknown>;
+  const typeName = getZodTypeName(schema);
+
+  switch (typeName) {
+    case "ZodString":
+    case "string":
+      return "example";
+    case "ZodNumber":
+    case "number":
+      return 0;
+    case "ZodBoolean":
+    case "boolean":
+      return true;
+    case "ZodLiteral":
+    case "literal":
+      return def.value;
+    case "ZodEnum":
+    case "enum": {
+      if (Array.isArray(def.values) && def.values.length > 0)
+        return def.values[0];
+      if (def.entries && typeof def.entries === "object") {
+        const values = Object.values(def.entries as Record<string, string>);
+        return values.length > 0 ? values[0] : "example";
+      }
+      return "example";
+    }
+    case "ZodOptional":
+    case "optional":
+    case "ZodNullable":
+    case "nullable":
+    case "ZodDefault":
+    case "default": {
+      const inner = (def.innerType as z.ZodType) ?? (def.wrapped as z.ZodType);
+      return inner ? generateExampleValue(inner) : null;
+    }
+    case "ZodArray":
+    case "array":
+      return [];
+    case "ZodObject":
+    case "object":
+      return generateExamplePropsFromZod(schema);
+    case "ZodUnion":
+    case "union": {
+      const options = def.options as z.ZodType[] | undefined;
+      return options && options.length > 0
+        ? generateExampleValue(options[0]!)
+        : "...";
+    }
+    default:
+      return "...";
+  }
+}
+
+/**
+ * Find the name of the first required string prop in a Zod object schema.
+ * Used to demonstrate $path dynamic bindings in examples.
+ */
+function findFirstStringProp(schema?: z.ZodType): string | null {
+  if (!schema || !schema._def) return null;
+  const def = schema._def as unknown as Record<string, unknown>;
+  const typeName = getZodTypeName(schema);
+
+  if (typeName !== "ZodObject" && typeName !== "object") return null;
+
+  const shape =
+    typeof def.shape === "function"
+      ? (def.shape as () => Record<string, z.ZodType>)()
+      : (def.shape as Record<string, z.ZodType>);
+  if (!shape) return null;
+
+  for (const [key, value] of Object.entries(shape)) {
+    const innerTypeName = getZodTypeName(value);
+    // Skip optional props
+    if (
+      innerTypeName === "ZodOptional" ||
+      innerTypeName === "optional" ||
+      innerTypeName === "ZodNullable" ||
+      innerTypeName === "nullable"
+    ) {
+      continue;
+    }
+    // Unwrap to check the actual type
+    if (innerTypeName === "ZodString" || innerTypeName === "string") {
+      return key;
+    }
+  }
+  return null;
+}
+
+// =============================================================================
+// Zod Introspection Helpers
+// =============================================================================
 
 /**
  * Get Zod type name from schema (handles different Zod versions)

--- a/packages/react-native/src/catalog.ts
+++ b/packages/react-native/src/catalog.ts
@@ -28,6 +28,7 @@ export const standardComponentDefinitions = {
     slots: ["default"],
     description:
       "Generic container wrapper. Use for grouping elements with padding, margin, and background color.",
+    example: { padding: 16, backgroundColor: "#FFFFFF" },
   },
 
   Row: {
@@ -53,6 +54,7 @@ export const standardComponentDefinitions = {
     slots: ["default"],
     description:
       "Horizontal flex layout. Use for placing elements side by side.",
+    example: { gap: 12, alignItems: "center" },
   },
 
   Column: {
@@ -77,6 +79,7 @@ export const standardComponentDefinitions = {
     slots: ["default"],
     description:
       "Vertical flex layout. Use for stacking elements top to bottom.",
+    example: { gap: 12, padding: 16 },
   },
 
   ScrollContainer: {
@@ -143,6 +146,7 @@ export const standardComponentDefinitions = {
     slots: [],
     description:
       "Heading text at various levels. h1 is largest, h4 is smallest.",
+    example: { text: "Welcome", level: "h1" },
   },
 
   Paragraph: {
@@ -156,6 +160,7 @@ export const standardComponentDefinitions = {
     slots: [],
     description:
       "Body text paragraph. Use for descriptions and longer content.",
+    example: { text: "This is a paragraph of body text." },
   },
 
   Label: {
@@ -168,6 +173,7 @@ export const standardComponentDefinitions = {
     slots: [],
     description:
       "Small utility text. Use for captions, form labels, and secondary information.",
+    example: { text: "Status", size: "sm" },
   },
 
   Image: {
@@ -181,6 +187,12 @@ export const standardComponentDefinitions = {
     }),
     slots: [],
     description: "Image display. Provide a source URL and optional dimensions.",
+    example: {
+      src: "https://picsum.photos/300/200",
+      alt: "Photo",
+      width: 300,
+      height: 200,
+    },
   },
 
   Avatar: {
@@ -193,6 +205,7 @@ export const standardComponentDefinitions = {
     slots: [],
     description:
       "Circular avatar showing an image or initials. Use for user profiles and contacts.",
+    example: { initials: "JD", size: "md" },
   },
 
   Badge: {
@@ -205,6 +218,7 @@ export const standardComponentDefinitions = {
     slots: [],
     description:
       "Small colored indicator with a label. Use for status, counts, and categories.",
+    example: { label: "New", variant: "info" },
   },
 
   Chip: {
@@ -237,6 +251,7 @@ export const standardComponentDefinitions = {
     slots: [],
     description:
       "Pressable button with label. Set variant for styling. Bind on.press for the handler to call on press.",
+    example: { label: "Submit", variant: "primary" },
   },
 
   TextInput: {
@@ -257,6 +272,11 @@ export const standardComponentDefinitions = {
     slots: [],
     description:
       "Text input field. Use statePath to bind to the state model for two-way binding. The value typed by the user is stored at the statePath.",
+    example: {
+      placeholder: "Enter text...",
+      statePath: "/inputValue",
+      label: "Name",
+    },
   },
 
   Switch: {
@@ -351,6 +371,7 @@ export const standardComponentDefinitions = {
     slots: ["default"],
     description:
       "Elevated card container with optional title. Use for grouping related content.",
+    example: { title: "Details", padding: 16, elevated: true },
   },
 
   ListItem: {
@@ -365,6 +386,11 @@ export const standardComponentDefinitions = {
     slots: [],
     description:
       "List row with title, subtitle, and optional leading/trailing text. Bind on.press for the press handler.",
+    example: {
+      title: "Settings",
+      subtitle: "Manage your preferences",
+      showChevron: true,
+    },
   },
 
   Modal: {

--- a/packages/react-native/src/schema.ts
+++ b/packages/react-native/src/schema.ts
@@ -38,6 +38,8 @@ export const schema = defineSchema(
         slots: s.array(s.string()),
         /** Description for AI generation hints */
         description: s.string(),
+        /** Example prop values used in prompt examples (auto-generated from Zod schema if omitted) */
+        example: s.any(),
       }),
       /** Action definitions (optional) */
       actions: s.map({

--- a/packages/react/src/schema.ts
+++ b/packages/react/src/schema.ts
@@ -38,6 +38,8 @@ export const schema = defineSchema(
         slots: s.array(s.string()),
         /** Description for AI generation hints */
         description: s.string(),
+        /** Example prop values used in prompt examples (auto-generated from Zod schema if omitted) */
+        example: s.any(),
       }),
       /** Action definitions (optional) */
       actions: s.map({

--- a/packages/remotion/src/catalog.ts
+++ b/packages/remotion/src/catalog.ts
@@ -21,6 +21,7 @@ export const standardComponentDefinitions = {
     defaultDuration: 90,
     description:
       "Full-screen title card with centered text. Use for intros, outros, and section breaks.",
+    example: { title: "Welcome", subtitle: "An introduction" },
   },
 
   ImageSlide: {
@@ -34,6 +35,11 @@ export const standardComponentDefinitions = {
     defaultDuration: 150,
     description:
       "Full-screen image display. Use for product shots, photos, and visual content.",
+    example: {
+      src: "https://picsum.photos/1920/1080?random=1",
+      alt: "Hero image",
+      fit: "cover",
+    },
   },
 
   SplitScreen: {
@@ -61,6 +67,10 @@ export const standardComponentDefinitions = {
     defaultDuration: 150,
     description:
       "Quote display with author. Props: quote, author, textColor, backgroundColor. Set transparent:true when using as overlay on images.",
+    example: {
+      quote: "The best way to predict the future is to invent it.",
+      author: "Alan Kay",
+    },
   },
 
   StatCard: {
@@ -74,6 +84,7 @@ export const standardComponentDefinitions = {
     type: "scene",
     defaultDuration: 90,
     description: "Large statistic display. Use for key metrics and numbers.",
+    example: { value: "10M+", label: "Users worldwide", prefix: "" },
   },
 
   TypingText: {


### PR DESCRIPTION
- Dynamically generate prompt examples from the user's actual catalog instead of hardcoding component names like `Stack`, `Column`, `Pressable`
- Add `example` field to `ComponentDefinition` and populate across all catalogs so prompt examples show realistic props instead of empty `props: {}`
- Fall back to Zod schema introspection for components without explicit examples
- Mention RFC 6902 in the output format section to leverage LLM training weights
- Generalize platform default rules to reference component categories instead of specific names

Fixes #88