### PR TITLE
feat: add support for using named slots

### DIFF
--- a/apps/web/app/(main)/docs/catalog/page.mdx
+++ b/apps/web/app/(main)/docs/catalog/page.mdx
@@ -70,12 +70,42 @@ Each component in the catalog has:
 ```typescript
 {
   props: z.object({...}),  // Zod schema for props (use .nullable() for optional)
-  slots?: string[],        // Named slots for children (e.g., ["default"])
+  slots?: string[],        // Named slots for children (e.g., ["default", "header", "footer"])
   description?: string,    // Help AI understand when to use it
 }
 ```
 
-Use `slots: ["default"]` for components that can contain children. The slot name corresponds to where child elements are rendered.
+### Named Slots
+
+Components can define multiple named slots:
+
+```typescript
+const catalog = defineCatalog(schema, {
+  components: {
+    // Simple component with just default slot
+    Card: {
+      props: z.object({ title: z.string() }),
+      slots: ["default"],
+      description: "Container card",
+    },
+    
+    // Component with multiple named slots
+    Layout: {
+      props: z.object({}),
+      slots: ["default", "header", "footer"],
+      description: "Full-page layout with header, main content, and footer",
+    },
+  },
+});
+```
+
+The `slots` array lists all available slots:
+- `"default"` - The main content slot, mapped from the `children` field in specs
+- Other names (e.g., `"header"`, `"footer"`) - Named slots, mapped from the `slots` field in specs
+
+When implementing the component in your registry, you'll receive:
+- `children` prop - Content for the default slot
+- `slots` prop - Object with content for named slots (e.g., `{ header: ReactNode, footer: ReactNode }`)
 
 ## Generating AI Prompts
 

--- a/apps/web/app/(main)/docs/registry/page.mdx
+++ b/apps/web/app/(main)/docs/registry/page.mdx
@@ -70,7 +70,7 @@ Each component receives a `ComponentContext` object:
 interface ComponentContext {
   props: T;                                // Type-safe props from your catalog
   children?: React.ReactNode;              // Rendered children (for slot components)
-  emit: (event: string) => void;           // Emit a named event (always defined)
+  slots?: Record<string, React.ReactNode>;  // Named slots (header, footer, etc.)
   on: (event: string) => EventHandle;      // Get event handle with metadata
   loading?: boolean;                       // Whether the renderer is in a loading state
   bindings?: Record<string, string>;       // State paths from $bindState/$bindItem expressions
@@ -124,6 +124,26 @@ TextInput: ({ props, bindings }) => {
 ```
 
 `useBoundProp` returns `[resolvedValue, setter]`. The setter writes to the bound state path. If no binding exists (the prop is a literal), the setter is a no-op.
+
+### Named Slots
+
+Components can define multiple named slots:
+
+```tsx
+export const { registry } = defineRegistry(myCatalog, {
+  components: {
+    Layout: ({ children, slots }) => (
+      <div className="layout">
+        <header>{slots?.header}</header>
+        <main>{children}</main>
+        <footer>{slots?.footer}</footer>
+      </div>
+    ),
+  },
+});
+```
+
+The `children` prop receives content from the `children` field in the spec, `slots` receives named slots content. See the [catalog documentation](/docs/catalog#named-slots) for more details.
 
 ### Action Handlers
 

--- a/apps/web/app/(main)/docs/specs/page.mdx
+++ b/apps/web/app/(main)/docs/specs/page.mdx
@@ -174,13 +174,18 @@ Each element in the map has a consistent shape:
 {
   "type": "ComponentName",
   "props": { "label": "Hello" },
-  "children": ["child-1", "child-2"]
+  "children": ["child-1", "child-2"],
+  "slots": {
+    "slot-1": ["child-3"],
+    "slot-2": ["child-4", "child-5"]
+  }
 }
 ```
 
 - `type` — Component type from your catalog
 - `props` — Component properties
-- `children` — Array of child element keys
+- `children` — Array of child element keys (maps to default slot)
+- `slots` — Object mapping slot names to arrays of child element keys
 
 ### Dynamic Data
 

--- a/packages/codegen/src/traverse.ts
+++ b/packages/codegen/src/traverse.ts
@@ -37,6 +37,14 @@ export function traverseSpec(
         visit(childKey, depth + 1, element);
       }
     }
+
+    if (element.slots) {
+      for (const slotChildren of Object.values(element.slots)) {
+        for (const childKey of slotChildren) {
+          visit(childKey, depth + 1, element);
+        }
+      }
+    }
   }
 
   visit(rootKey, 0, null);

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -754,14 +754,14 @@ Note: state patches appear right after the elements that use them, so the UI fil
 
     for (const [name, def] of Object.entries(components)) {
       const propsStr = def.props ? formatZodType(def.props) : "{}";
-      const hasChildren = def.slots && def.slots.length > 0;
-      const childrenStr = hasChildren ? " [accepts children]" : "";
+      const hasSlots = def.slots && def.slots.length > 0;
+      const slotsStr = hasSlots ? ` [slots: ${def.slots!.join(", ")}]` : "";
       const eventsStr =
         def.events && def.events.length > 0
           ? ` [events: ${def.events.join(", ")}]`
           : "";
       const descStr = def.description ? ` - ${def.description}` : "";
-      lines.push(`- ${name}: ${propsStr}${descStr}${childrenStr}${eventsStr}`);
+      lines.push(`- ${name}: ${propsStr}${descStr}${slotsStr}${eventsStr}`);
     }
     lines.push("");
   }
@@ -959,6 +959,7 @@ Note: state patches appear right after the elements that use them, so the UI fil
           "Output /state patches right after the elements that use them, one per array item for progressive loading. REQUIRED whenever using $state, $bindState, $bindItem, $item, $index, or repeat.",
           "ONLY use components listed above",
           "Each element value needs: type, props, children (array of child keys)",
+          "Use children for the default slot. Use slots object for named slots (e.g., slots: { header: [...], footer: [...] }). Never use slots.default - that's what children is for",
           "Use unique keys for the element map entries (e.g., 'header', 'metric-1', 'chart-revenue')",
         ]
       : [
@@ -968,6 +969,7 @@ Note: state patches appear right after the elements that use them, so the UI fil
           "Output /state patches right after the elements that use them, one per array item for progressive loading. REQUIRED whenever using $state, $bindState, $bindItem, $item, $index, or repeat.",
           "ONLY use components listed above",
           "Each element value needs: type, props, children (array of child keys)",
+          "Use children for the default slot. Use slots object for named slots (e.g., slots: { header: [...], footer: [...] }). Never use slots.default - that's what children is for",
           "Use unique keys for the element map entries (e.g., 'header', 'metric-1', 'chart-revenue')",
         ];
   const schemaRules = catalog.schema.defaultRules ?? [];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -61,8 +61,10 @@ export interface UIElement<
   type: T;
   /** Component props */
   props: P;
-  /** Child element keys (flat structure) */
+  /** Child element keys (flat structure) - maps to the 'default' slot */
   children?: string[];
+  /** Named slots - maps slot names to arrays of child element keys */
+  slots?: Record<string, string[]>;
   /** Visibility condition */
   visible?: VisibilityCondition;
   /** Event bindings — maps event names to action bindings */

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,7 +57,8 @@
     "@internal/typescript-config": "workspace:*",
     "@types/react": "19.2.3",
     "tsup": "^8.0.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "zod": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^19.2.3"

--- a/packages/react/src/catalog-types.ts
+++ b/packages/react/src/catalog-types.ts
@@ -60,6 +60,7 @@ export interface EventHandle {
 export interface BaseComponentProps<P = Record<string, unknown>> {
   props: P;
   children?: ReactNode;
+  slots?: Record<string, ReactNode>;
   /** Simple event emitter (shorthand). Fires the event and returns void. */
   emit: (event: string) => void;
   /** Get an event handle with metadata. Use when you need shouldPreventDefault or bound checks. */

--- a/packages/react/src/renderer.test.tsx
+++ b/packages/react/src/renderer.test.tsx
@@ -1,11 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import React from "react";
 import { render } from "@testing-library/react";
 import {
+  defineRegistry,
   Renderer,
   JSONUIProvider,
 } from "./renderer";
-import type { Spec } from "@json-render/core";
+import { defineCatalog, type Spec } from "@json-render/core";
+import { z } from "zod";
+import { schema } from "./schema";
 
 describe("Renderer", () => {
   it("renders null for null spec", () => {
@@ -76,24 +79,36 @@ describe("Renderer - Named Slots", () => {
       },
     };
 
-    const registry = {
-      Layout: ({
-        children,
-        slots,
-      }: {
-        children?: React.ReactNode;
-        slots?: Record<string, React.ReactNode>;
-      }) => (
-        <div data-testid="layout">
-          <header data-testid="header-slot">{slots?.header}</header>
-          <main data-testid="main-slot">{children}</main>
-          <footer data-testid="footer-slot">{slots?.footer}</footer>
-        </div>
-      ),
-      Text: ({ element }: { element: { props: { content: string } } }) => (
-        <span data-testid="text">{element.props.content}</span>
-      ),
-    };
+    const catalog = defineCatalog(schema, {
+      components: {
+        Layout: {
+          props: z.object({}),
+          slots: ["header", "footer"],
+          description: "Layout component with header and footer slots",
+        },
+        Text: {
+          props: z.object({ content: z.string() }),
+          slots: [],
+          description: "Text component",
+        },
+      },
+      actions: {},
+    });
+
+    const { registry } = defineRegistry(catalog, {
+      components: {
+        Layout: ({ children, slots }) => (
+          <div data-testid="layout">
+            <header data-testid="header-slot">{slots?.header}</header>
+            <main data-testid="main-slot">{children}</main>
+            <footer data-testid="footer-slot">{slots?.footer}</footer>
+          </div>
+        ),
+        Text: ({ props }: { props: { content: string } }) => (
+          <span data-testid="text">{props.content}</span>
+        ),
+      },
+    });
 
     const { getByTestId, getAllByTestId } = render(
       <JSONUIProvider registry={registry}>
@@ -137,19 +152,30 @@ describe("Renderer - Named Slots", () => {
       },
     };
 
-    const registry = {
-      Layout: ({ slots }: { slots?: Record<string, React.ReactNode> }) => (
-        <div>{slots?.sidebar}</div>
-      ),
-      Text: ({ element }: { element: { props: { content: string } } }) => (
-        <span>{element.props.content}</span>
-      ),
-      __metadata__: {
-        components: {
-          Layout: { slots: ["header", "footer"] }, // sidebar NOT included
+    const catalog = defineCatalog(schema, {
+      components: {
+        Layout: {
+          props: z.object({}),
+          slots: ["header", "footer"], // sidebar NOT included
+          description: "Layout component",
+        },
+        Text: {
+          props: z.object({ content: z.string() }),
+          slots: [],
+          description: "Text component",
         },
       },
-    };
+      actions: {},
+    });
+
+    const { registry } = defineRegistry(catalog, {
+      components: {
+        Layout: ({ slots }) => <div>{slots?.sidebar}</div>,
+        Text: ({ props }: { props: { content: string } }) => (
+          <span>{props.content}</span>
+        ),
+      },
+    });
 
     render(
       <JSONUIProvider registry={registry}>
@@ -189,28 +215,35 @@ describe("Renderer - Named Slots", () => {
       },
     };
 
-    const registry = {
-      Layout: ({
-        children,
-        slots,
-      }: {
-        children?: React.ReactNode;
-        slots?: Record<string, React.ReactNode>;
-      }) => (
-        <div data-testid="layout">
-          <div data-testid="default-slot">{slots?.default}</div>
-          <div data-testid="children">{children}</div>
-        </div>
-      ),
-      Text: ({ element }: { element: { props: { content: string } } }) => (
-        <span>{element.props.content}</span>
-      ),
-      __metadata__: {
-        components: {
-          Layout: { slots: ["header", "footer"] }, // default NOT included
+    const catalog = defineCatalog(schema, {
+      components: {
+        Layout: {
+          props: z.object({}),
+          slots: ["header", "footer"], // default NOT included
+          description: "Layout component",
+        },
+        Text: {
+          props: z.object({ content: z.string() }),
+          slots: [],
+          description: "Text component",
         },
       },
-    };
+      actions: {},
+    });
+
+    const { registry } = defineRegistry(catalog, {
+      components: {
+        Layout: ({ children, slots }) => (
+          <div data-testid="layout">
+            <div data-testid="default-slot">{slots?.default}</div>
+            <div data-testid="children">{children}</div>
+          </div>
+        ),
+        Text: ({ props }: { props: { content: string } }) => (
+          <span>{props.content}</span>
+        ),
+      },
+    });
 
     const { getByTestId } = render(
       <JSONUIProvider registry={registry}>
@@ -254,23 +287,35 @@ describe("Renderer - Named Slots", () => {
       },
     };
 
-    const registry = {
-      Layout: ({
-        children,
-        slots,
-      }: {
-        children?: React.ReactNode;
-        slots?: Record<string, React.ReactNode>;
-      }) => (
-        <div data-testid="layout">
-          <header data-testid="header">{slots?.header}</header>
-          <main>{children}</main>
-        </div>
-      ),
-      Text: ({ element }: { element: { props: { content: string } } }) => (
-        <span>{element.props.content}</span>
-      ),
-    };
+    const catalog = defineCatalog(schema, {
+      components: {
+        Layout: {
+          props: z.object({}),
+          slots: ["header", "footer"],
+          description: "Layout component",
+        },
+        Text: {
+          props: z.object({ content: z.string() }),
+          slots: [],
+          description: "Text component",
+        },
+      },
+      actions: {},
+    });
+
+    const { registry } = defineRegistry(catalog, {
+      components: {
+        Layout: ({ children, slots }) => (
+          <div data-testid="layout">
+            <header data-testid="header">{slots?.header}</header>
+            <main>{children}</main>
+          </div>
+        ),
+        Text: ({ props }: { props: { content: string } }) => (
+          <span>{props.content}</span>
+        ),
+      },
+    });
 
     const { getByTestId } = render(
       <JSONUIProvider registry={registry}>

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -600,7 +600,7 @@ type DefineRegistryOptions<C extends Catalog> = {
  * ```
  */
 export function defineRegistry<C extends Catalog>(
-  _catalog: C,
+  catalog: C,
   options: DefineRegistryOptions<C>,
 ): DefineRegistryResult {
   // Build component registry

--- a/packages/react/src/schema.ts
+++ b/packages/react/src/schema.ts
@@ -20,8 +20,10 @@ export const schema = defineSchema(
           type: s.ref("catalog.components"),
           /** Component props */
           props: s.propsOf("catalog.components"),
-          /** Child element keys (flat reference) */
+          /** Child element keys (flat reference) - maps to the 'default' slot */
           children: s.array(s.string()),
+          /** Named slots - maps slot names to arrays of child element keys */
+          slots: s.record(s.array(s.string())),
           /** Visibility condition */
           visible: s.any(),
         }),
@@ -72,6 +74,9 @@ export const schema = defineSchema(
       // Element integrity
       "CRITICAL INTEGRITY CHECK: Before outputting ANY element that references children, you MUST have already output (or will output) each child as its own element. If an element has children: ['a', 'b'], then elements 'a' and 'b' MUST exist. A missing child element causes that entire branch of the UI to be invisible.",
       "SELF-CHECK: After generating all elements, mentally walk the tree from root. Every key in every children array must resolve to a defined element. If you find a gap, output the missing element immediately.",
+
+      // Named slots
+      'Components may declare named slots in their catalog definition (e.g., slots: ["header", "footer"]). Example: {"type":"Layout","props":{},"slots":{"header":["h1"],"footer":["f1"]},"children":["main1"]}. Verify slot names exist in the component\'s catalog definition and all referenced child element keys exist.',
 
       // Field placement
       'CRITICAL: The "visible" field goes on the ELEMENT object, NOT inside "props". Correct: {"type":"<ComponentName>","props":{},"visible":{"$state":"/tab","eq":"home"},"children":[...]}.',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -907,6 +907,9 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.9.2
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.5
 
   packages/react-native:
     dependencies:

--- a/skills/json-render-react/SKILL.md
+++ b/skills/json-render-react/SKILL.md
@@ -44,7 +44,13 @@ export const catalog = defineCatalog(schema, {
     },
     Card: {
       props: z.object({ title: z.string() }),
+      slots: ["default"],
       description: "Card container with title",
+    },
+    Layout: {
+      props: z.object({}),
+      slots: ["default", "header", "footer"],
+      description: "Full-page layout with named slots",
     },
   },
 });
@@ -59,6 +65,13 @@ const { registry } = defineRegistry(catalog, {
       <div className="card">
         <h2>{props.title}</h2>
         {children}
+      </div>
+    ),
+    Layout: ({ children, slots }) => (
+      <div className="layout">
+        <header>{slots?.header}</header>
+        <main>{children}</main>
+        <footer>{slots?.footer}</footer>
       </div>
     ),
   },
@@ -80,6 +93,80 @@ The React schema uses an element tree format:
   }
 }
 ```
+
+## Named Slots
+
+Components can define multiple named slots for flexible content placement. The `children` field maps to the default slot, while the `slots` field provides explicit slot assignments.
+
+### Defining Components with Named Slots
+
+```typescript
+// In catalog - declare available slots
+export const catalog = defineCatalog(schema, {
+  components: {
+    Layout: {
+      props: z.object({}),
+      slots: ["default", "header", "footer"],
+      description: "Layout with header, main content, and footer",
+    },
+  },
+});
+
+// In registry - receive slots via props
+const { registry } = defineRegistry(catalog, {
+  components: {
+    Layout: ({ children, slots }) => (
+      <div>
+        <header>{slots?.header}</header>
+        <main>{children}</main>
+        <footer>{slots?.footer}</footer>
+      </div>
+    ),
+  },
+});
+```
+
+### Using Named Slots in Specs
+
+```json
+{
+  "root": "layout",
+  "elements": {
+    "layout": {
+      "type": "Layout",
+      "props": {},
+      "slots": {
+        "header": ["nav-bar"],
+        "footer": ["footer-content", "footer-copyright"]
+      },
+      "children": ["main-content"]
+    },
+    "nav-bar": {
+      "type": "Text",
+      "props": { "text": "Navigation" }
+    },
+    "main-content": {
+      "type": "Text",
+      "props": { "text": "Main content" }
+    },
+    "footer-content": {
+      "type": "Text",
+      "props": { "text": "Footer" }
+    },
+    "footer-copyright": {
+      "type": "Text",
+      "props": { "text": "© 2026" }
+    }
+  }
+}
+```
+
+### Slot Assignment Rules
+
+- **`children`** → Maps to the default slot (always use this for default content)
+- **`slots.header`, `slots.footer`, etc.** → Named slots for specific placement
+- **Never use `slots.default`** → This is incorrect; use `children` instead
+- Components receive `children` prop (default slot) and `slots` prop (named slots)
 
 ## Visibility Conditions
 


### PR DESCRIPTION
Builds on recently committed support for defining component slots in catalog to add support for actually using named slots in spec generation and rendering.

Updated:
- core system prompt,
- codegen traversal,
- react renderer, schema and types,
- json-render-react skill,
- playground,
- docs.

Resolves https://github.com/vercel-labs/json-render/issues/39.