### PR TITLE
Align rendering of ai-sdk table with other patterns

### DIFF
--- a/apps/web/app/(main)/docs/ai-sdk/page.mdx
+++ b/apps/web/app/(main)/docs/ai-sdk/page.mdx
@@ -194,39 +194,40 @@ In chat mode, the prompt instructs the AI to respond conversationally first, the
 <div className="my-6 overflow-x-auto">
   <table className="mdx-table w-full text-sm border-collapse">
     <thead>
-     <tr>
-      <th></th>
-      <th>Generate</th>
-      <th>Chat</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Output</td>
-      <td>JSONL only</td>
-      <td>Text + JSONL</td>
-    </tr>
-    <tr>
-      <td>Text-only replies</td>
-      <td>No</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <td>System prompt</td>
-      <td><code>catalog.prompt()</code></td>
-      <td><code>catalog.prompt({ mode: "chat" })</code></td>
-    </tr>
-    <tr>
-      <td>Stream utility</td>
-      <td><code>useUIStream</code></td>
-      <td><code>pipeJsonRender</code> + <code>useJsonRenderMessage</code></td>
-    </tr>
-    <tr>
-      <td>Use case</td>
-      <td>Playgrounds, builders</td>
-      <td>Chatbots, copilots</td>
-    </tr>
-  </tbody>
+      <tr>
+        <th></th>
+        <th>Generate</th>
+        <th>Chat</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Output</td>
+        <td>JSONL only</td>
+        <td>Text + JSONL</td>
+      </tr>
+      <tr>
+        <td>Text-only replies</td>
+        <td>No</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>System prompt</td>
+        <td><code>catalog.prompt()</code></td>
+        <td><code>catalog.prompt({ mode: "chat" })</code></td>
+      </tr>
+      <tr>
+        <td>Stream utility</td>
+        <td><code>useUIStream</code></td>
+        <td><code>pipeJsonRender</code> + <code>useJsonRenderMessage</code></td>
+      </tr>
+      <tr>
+        <td>Use case</td>
+        <td>Playgrounds, builders</td>
+        <td>Chatbots, copilots</td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 
 Learn more in the [Generation Modes](/docs/generation-modes) guide.


### PR DESCRIPTION
https://json-render.dev/docs/ai-sdk has a broken markdown table render

<img width="727" height="182" alt="image" src="https://github.com/user-attachments/assets/2d70d656-af15-49bb-bcfd-5c27319c4237" />


Without a remark/rehype gfm plugin, we need to render markdown tables as pure HTML.

I copied the approach from https://github.com/vercel-labs/json-render/blob/main/apps/web/app/(main)/docs/generation-modes/page.mdx?plain=1