### PR TITLE
fix(web): add post-generation verification step and harden generated spec handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ json-render is a **Generative UI** framework: AI generates interfaces from natur
 - **Guardrailed** - AI can only use components in your catalog
 - **Predictable** - JSON output matches your schema, every time
 - **Fast** - Stream and render progressively as the model responds
+- **Verifiable** - Playground includes a post-generation verification + quick feedback loop
 - **Cross-Platform** - React (web) and React Native (mobile) from the same catalog
 - **Batteries Included** - 36 pre-built shadcn/ui components ready to use
 

--- a/apps/web/app/api/generate/route.ts
+++ b/apps/web/app/api/generate/route.ts
@@ -15,6 +15,8 @@ const SYSTEM_PROMPT = playgroundCatalog.prompt({
     "Wrap each repeated item in a Card for visual separation and structure.",
     "Use realistic, professional sample data. Include 3-5 items with varied content. Never leave state arrays empty.",
     'For form inputs (Input, Textarea, Select), always include checks for validation (e.g. required, email, minLength). Always pair checks with a $bindState expression on the value prop (e.g. { "$bindState": "/path" }).',
+    'For Rating used in forms/feedback, make it interactive: bind props.value with { "$bindState": "/path" } and provide on.change to update state.',
+    "For Select and Radio options, output plain string arrays only (e.g. ['Small','Medium','Large']). Do not output raw option objects.",
   ],
 });
 

--- a/apps/web/components/playground.tsx
+++ b/apps/web/components/playground.tsx
@@ -19,6 +19,10 @@ import { Sheet, SheetContent, SheetTitle } from "./ui/sheet";
 import { PlaygroundRenderer } from "@/lib/render/renderer";
 import { playgroundCatalog } from "@/lib/render/catalog";
 import { buildCatalogDisplayData } from "@/lib/render/catalog-display";
+import {
+  verifyPlaygroundSpec,
+  buildVerificationFixPrompt,
+} from "@/lib/render/spec-verifier";
 
 type Tab = "json" | "nested" | "stream" | "catalog";
 type RenderView = "preview" | "code";
@@ -33,10 +37,19 @@ type MobileView =
 interface Version {
   id: string;
   prompt: string;
+  requestPrompt: string;
+  originPrompt: string;
   tree: Spec | null;
   status: "generating" | "complete" | "error";
   usage: TokenUsage | null;
   rawLines: string[];
+}
+
+interface StartGenerationOptions {
+  requestPrompt: string;
+  displayPrompt: string;
+  previousSpec: Spec | null;
+  originPrompt: string;
 }
 
 /**
@@ -104,6 +117,9 @@ export function Playground() {
   const [renderView, setRenderView] = useState<RenderView>("preview");
   const [mobileView, setMobileView] = useState<MobileView>("preview");
   const [versionsSheetOpen, setVersionsSheetOpen] = useState(false);
+  const [verificationFeedback, setVerificationFeedback] = useState<
+    Record<string, "accepted" | "fix-requested">
+  >({});
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const mobileInputRef = useRef<HTMLTextAreaElement>(null);
   const versionsEndRef = useRef<HTMLDivElement>(null);
@@ -141,6 +157,18 @@ export function Playground() {
 
   // Get the selected version
   const selectedVersion = versions.find((v) => v.id === selectedVersionId);
+  const selectedVersionIndex = selectedVersion
+    ? versions.findIndex((v) => v.id === selectedVersion.id)
+    : -1;
+  const selectedVerification = useMemo(() => {
+    if (!selectedVersion?.tree || selectedVersion.status !== "complete") {
+      return null;
+    }
+    return verifyPlaygroundSpec(selectedVersion.tree);
+  }, [selectedVersion]);
+  const selectedVerificationFeedback = selectedVersionId
+    ? verificationFeedback[selectedVersionId]
+    : undefined;
 
   // Determine which tree to display:
   // - If streaming and selected version is the generating one, show apiSpec
@@ -201,27 +229,119 @@ export function Playground() {
     }
   }, [isStreaming, apiSpec, streamUsage, streamRawLines]);
 
+  const handleClearAll = useCallback(() => {
+    setVersions([]);
+    setSelectedVersionId(null);
+    setVerificationFeedback({});
+    clear();
+    currentTreeRef.current = null;
+    generatingVersionIdRef.current = null;
+  }, [clear]);
+
+  const startGeneration = useCallback(
+    async ({
+      requestPrompt,
+      displayPrompt,
+      previousSpec,
+      originPrompt,
+    }: StartGenerationOptions) => {
+      const trimmedPrompt = requestPrompt.trim();
+      if (!trimmedPrompt || isStreaming) return;
+
+      const newVersionId = Date.now().toString();
+      const newVersion: Version = {
+        id: newVersionId,
+        prompt: displayPrompt,
+        requestPrompt: trimmedPrompt,
+        originPrompt,
+        tree: null,
+        status: "generating",
+        usage: null,
+        rawLines: [],
+      };
+
+      generatingVersionIdRef.current = newVersionId;
+      setVersions((prev) => [...prev, newVersion]);
+      setSelectedVersionId(newVersionId);
+
+      await send(trimmedPrompt, { previousSpec: previousSpec ?? undefined });
+    },
+    [isStreaming, send],
+  );
+
   const handleSubmit = useCallback(async () => {
-    if (!inputValue.trim() || isStreaming) return;
+    const prompt = inputValue.trim();
+    if (!prompt || isStreaming) return;
 
-    const newVersionId = Date.now().toString();
-    const newVersion: Version = {
-      id: newVersionId,
-      prompt: inputValue.trim(),
-      tree: null,
-      status: "generating",
-      usage: null,
-      rawLines: [],
-    };
-
-    generatingVersionIdRef.current = newVersionId;
-    setVersions((prev) => [...prev, newVersion]);
-    setSelectedVersionId(newVersionId);
     setInputValue("");
+    await startGeneration({
+      requestPrompt: prompt,
+      displayPrompt: prompt,
+      previousSpec: currentTreeRef.current,
+      originPrompt: prompt,
+    });
+  }, [inputValue, isStreaming, startGeneration]);
 
-    // Pass the current tree as context so the API can iterate on it
-    await send(inputValue.trim(), { previousSpec: currentTreeRef.current });
-  }, [inputValue, isStreaming, send]);
+  const handleVerificationAccept = useCallback(() => {
+    if (!selectedVersionId) return;
+    setVerificationFeedback((prev) => ({
+      ...prev,
+      [selectedVersionId]: "accepted",
+    }));
+    toast.success("Verification feedback saved.");
+  }, [selectedVersionId]);
+
+  const handleVerificationFix = useCallback(async () => {
+    if (!selectedVersion || !selectedVersion.tree || isStreaming) return;
+
+    const issues = selectedVerification?.issues ?? [];
+    if (issues.length === 0) {
+      toast.success("No verification issues detected.");
+      return;
+    }
+
+    setVerificationFeedback((prev) => ({
+      ...prev,
+      [selectedVersion.id]: "fix-requested",
+    }));
+
+    const label =
+      selectedVersionIndex >= 0
+        ? `Fix verification issues for v${selectedVersionIndex + 1}`
+        : "Fix verification issues";
+
+    await startGeneration({
+      requestPrompt: buildVerificationFixPrompt({
+        originalPrompt: selectedVersion.originPrompt,
+        issues,
+      }),
+      displayPrompt: label,
+      previousSpec: selectedVersion.tree,
+      originPrompt: selectedVersion.originPrompt,
+    });
+  }, [
+    selectedVersion,
+    isStreaming,
+    selectedVerification,
+    selectedVersionIndex,
+    startGeneration,
+  ]);
+
+  const handleRegenerate = useCallback(async () => {
+    if (!selectedVersion || isStreaming) return;
+
+    const label =
+      selectedVersionIndex >= 0
+        ? `Regenerate v${selectedVersionIndex + 1}`
+        : "Regenerate";
+
+    await startGeneration({
+      requestPrompt: selectedVersion.originPrompt,
+      displayPrompt: label,
+      previousSpec: null,
+      originPrompt: selectedVersion.originPrompt,
+    });
+  }, [selectedVersion, isStreaming, selectedVersionIndex, startGeneration]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -303,6 +423,92 @@ ${jsx}
   );
 }`;
   }, [currentTree]);
+
+  const verificationIssues = selectedVerification?.issues ?? [];
+  const verificationErrorCount = verificationIssues.filter(
+    (issue) => issue.severity === "error",
+  ).length;
+  const verificationWarningCount =
+    verificationIssues.length - verificationErrorCount;
+
+  const verificationPanel =
+    selectedVersion?.status === "complete" && selectedVersion.tree ? (
+      <div className="border-b border-border px-3 py-2 bg-muted/20">
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="min-w-0">
+            <p className="text-xs font-mono text-foreground">
+              verification
+              {verificationIssues.length === 0
+                ? " passed"
+                : ` ${verificationErrorCount} error(s), ${verificationWarningCount} warning(s)`}
+            </p>
+            {selectedVerificationFeedback === "accepted" && (
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                Feedback: looks good
+              </p>
+            )}
+            {selectedVerificationFeedback === "fix-requested" && (
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                Feedback: fix requested
+              </p>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleVerificationAccept}
+              disabled={isStreaming || selectedVerificationFeedback === "accepted"}
+              className="text-[11px] px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors disabled:opacity-40"
+            >
+              Looks good
+            </button>
+            {verificationIssues.length > 0 && (
+              <button
+                onClick={handleVerificationFix}
+                disabled={isStreaming}
+                className="text-[11px] px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors disabled:opacity-40"
+              >
+                Fix issues
+              </button>
+            )}
+            <button
+              onClick={handleRegenerate}
+              disabled={isStreaming}
+              className="text-[11px] px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors disabled:opacity-40"
+            >
+              Regenerate
+            </button>
+          </div>
+        </div>
+        {verificationIssues.length > 0 && (
+          <div className="mt-2 space-y-1">
+            {verificationIssues.slice(0, 3).map((issue, idx) => (
+              <p key={`${issue.code}-${issue.elementKey ?? "root"}-${idx}`} className="text-[11px] text-muted-foreground">
+                [{issue.severity}] {issue.message}
+              </p>
+            ))}
+            {verificationIssues.length > 3 && (
+              <p className="text-[11px] text-muted-foreground">
+                +{verificationIssues.length - 3} more issue(s)
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    ) : null;
+
+  const previewContent = currentTree && currentTree.root ? (
+    <div className="w-full min-h-full flex items-center justify-center p-6">
+      <PlaygroundRenderer
+        spec={currentTree}
+        data={currentTree.state}
+        loading={isStreaming}
+      />
+    </div>
+  ) : (
+    <div className="h-full flex items-center justify-center text-muted-foreground/50 text-sm">
+      {isStreaming ? "generating..." : "// enter a prompt to generate UI"}
+    </div>
+  );
 
   // Chat pane content
   const chatPane = (
@@ -410,11 +616,7 @@ ${jsx}
         <div className="flex justify-between items-center mt-2">
           {versions.length > 0 ? (
             <button
-              onClick={() => {
-                setVersions([]);
-                setSelectedVersionId(null);
-                clear();
-              }}
+              onClick={handleClearAll}
               className="text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
               Clear
@@ -671,21 +873,10 @@ ${jsx}
       </div>
       <div className="flex-1 overflow-auto">
         {renderView === "preview" ? (
-          currentTree && currentTree.root ? (
-            <div className="w-full min-h-full flex items-center justify-center p-6">
-              <PlaygroundRenderer
-                spec={currentTree}
-                data={currentTree.state}
-                loading={isStreaming}
-              />
-            </div>
-          ) : (
-            <div className="h-full flex items-center justify-center text-muted-foreground/50 text-sm">
-              {isStreaming
-                ? "generating..."
-                : "// enter a prompt to generate UI"}
-            </div>
-          )
+          <div className="min-h-full flex flex-col">
+            {verificationPanel}
+            <div className="flex-1">{previewContent}</div>
+          </div>
         ) : (
           <CodeBlock
             code={generatedCode}
@@ -910,48 +1101,51 @@ ${jsx}
           ) : mobileView === "json" ? (
             <CodeBlock code={jsonCode} lang="json" fillHeight hideCopyButton />
           ) : mobileView === "preview" ? (
-            currentTree && currentTree.root ? (
-              <div className="w-full min-h-full flex items-center justify-center p-6">
-                <PlaygroundRenderer
-                  spec={currentTree}
-                  data={currentTree.state}
-                  loading={isStreaming}
-                />
-              </div>
-            ) : (
-              <div className="h-full flex flex-col items-center justify-center text-center px-4">
-                {isStreaming ? (
-                  <p className="text-sm text-muted-foreground/50">
-                    generating...
-                  </p>
-                ) : (
-                  <>
-                    <p className="text-sm text-muted-foreground mb-4">
-                      Describe what you want to build, then iterate on it.
+            <div className="min-h-full flex flex-col">
+              {verificationPanel}
+              {currentTree && currentTree.root ? (
+                <div className="w-full min-h-full flex items-center justify-center p-6">
+                  <PlaygroundRenderer
+                    spec={currentTree}
+                    data={currentTree.state}
+                    loading={isStreaming}
+                  />
+                </div>
+              ) : (
+                <div className="h-full flex flex-col items-center justify-center text-center px-4">
+                  {isStreaming ? (
+                    <p className="text-sm text-muted-foreground/50">
+                      generating...
                     </p>
-                    <div className="flex flex-wrap gap-2 justify-center">
-                      {EXAMPLE_PROMPTS.map((prompt) => (
-                        <button
-                          key={prompt}
-                          onMouseDown={(e) => {
-                            e.preventDefault();
-                            flushSync(() => setInputValue(prompt));
-                            mobileInputRef.current?.focus();
-                            mobileInputRef.current?.setSelectionRange(
-                              prompt.length,
-                              prompt.length,
-                            );
-                          }}
-                          className="text-xs px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors"
-                        >
-                          {prompt}
-                        </button>
-                      ))}
-                    </div>
-                  </>
-                )}
-              </div>
-            )
+                  ) : (
+                    <>
+                      <p className="text-sm text-muted-foreground mb-4">
+                        Describe what you want to build, then iterate on it.
+                      </p>
+                      <div className="flex flex-wrap gap-2 justify-center">
+                        {EXAMPLE_PROMPTS.map((prompt) => (
+                          <button
+                            key={prompt}
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              flushSync(() => setInputValue(prompt));
+                              mobileInputRef.current?.focus();
+                              mobileInputRef.current?.setSelectionRange(
+                                prompt.length,
+                                prompt.length,
+                              );
+                            }}
+                            className="text-xs px-2 py-1 rounded border border-border text-muted-foreground hover:text-foreground hover:border-foreground/30 transition-colors"
+                          >
+                            {prompt}
+                          </button>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
           ) : (
             /* generated-code */
             <CodeBlock
@@ -986,11 +1180,7 @@ ${jsx}
           <div className="flex justify-between items-center mt-2">
             {versions.length > 0 ? (
               <button
-                onClick={() => {
-                  setVersions([]);
-                  setSelectedVersionId(null);
-                  clear();
-                }}
+                onClick={handleClearAll}
                 className="text-xs text-muted-foreground hover:text-foreground transition-colors"
               >
                 Clear

--- a/apps/web/lib/render/catalog.ts
+++ b/apps/web/lib/render/catalog.ts
@@ -260,7 +260,9 @@ export const playgroundCatalog = defineCatalog(schema, {
         max: z.number().nullable(),
         label: z.string().nullable(),
       }),
-      description: "Star rating display",
+      events: ["change"],
+      description:
+        "Interactive rating input. Use { $bindState } on value for state binding and on.change for updates.",
     },
 
     // ── Charts ──────────────────────────────────────────────────────────
@@ -359,7 +361,7 @@ export const playgroundCatalog = defineCatalog(schema, {
       }),
       events: ["change"],
       description:
-        "Dropdown select input. Use { $bindState } on value for binding. Use checks for validation.",
+        "Dropdown select input. Use string options (e.g. ['Small','Medium','Large']). Use { $bindState } on value for binding. Use checks for validation.",
     },
 
     Checkbox: {
@@ -381,7 +383,7 @@ export const playgroundCatalog = defineCatalog(schema, {
       }),
       events: ["change"],
       description:
-        "Radio button group. Use { $bindState } on value for binding.",
+        "Radio button group. Use string options (e.g. ['Basic','Pro']). Use { $bindState } on value for binding.",
     },
 
     Switch: {

--- a/apps/web/lib/render/option-utils.ts
+++ b/apps/web/lib/render/option-utils.ts
@@ -1,0 +1,82 @@
+export interface NormalizedChoiceOption {
+  label: string;
+  value: string;
+  source: "string" | "primitive" | "object";
+}
+
+export interface ChoiceOptionNormalizationResult {
+  options: NormalizedChoiceOption[];
+  objectCount: number;
+  invalidCount: number;
+}
+
+function toText(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
+}
+
+function normalizeObjectOption(
+  option: Record<string, unknown>,
+): NormalizedChoiceOption | null {
+  const rawLabel =
+    option.label ?? option.name ?? option.title ?? option.text ?? option.value;
+  const rawValue =
+    option.value ?? option.id ?? option.key ?? option.label ?? option.name;
+  const label = toText(rawLabel);
+  const value = toText(rawValue);
+
+  if (!label || !value) return null;
+
+  return {
+    label: label.trim(),
+    value: value.trim(),
+    source: "object",
+  };
+}
+
+export function normalizeChoiceOptions(
+  rawOptions: unknown[],
+): ChoiceOptionNormalizationResult {
+  const options: NormalizedChoiceOption[] = [];
+  let objectCount = 0;
+  let invalidCount = 0;
+
+  for (const raw of rawOptions) {
+    if (typeof raw === "string") {
+      options.push({
+        label: raw,
+        value: raw,
+        source: "string",
+      });
+      continue;
+    }
+
+    if (typeof raw === "number" || typeof raw === "boolean") {
+      const text = String(raw);
+      options.push({
+        label: text,
+        value: text,
+        source: "primitive",
+      });
+      continue;
+    }
+
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+      objectCount += 1;
+      const normalized = normalizeObjectOption(raw as Record<string, unknown>);
+      if (normalized) {
+        options.push(normalized);
+      } else {
+        invalidCount += 1;
+      }
+      continue;
+    }
+
+    invalidCount += 1;
+  }
+
+  return { options, objectCount, invalidCount };
+}

--- a/apps/web/lib/render/spec-verifier.ts
+++ b/apps/web/lib/render/spec-verifier.ts
@@ -1,0 +1,194 @@
+import { validateSpec, type Spec, type UIElement } from "@json-render/core";
+
+import { normalizeChoiceOptions } from "./option-utils";
+
+export type SpecVerificationSeverity = "error" | "warning";
+
+export type SpecVerificationCode =
+  | "structural_issue"
+  | "rating_maybe_read_only"
+  | "rating_value_out_of_range"
+  | "choice_options_not_array"
+  | "choice_invalid_option_shape"
+  | "choice_object_options_detected"
+  | "choice_value_not_in_options";
+
+export interface SpecVerificationIssue {
+  severity: SpecVerificationSeverity;
+  code: SpecVerificationCode;
+  message: string;
+  elementKey?: string;
+}
+
+export interface SpecVerificationResult {
+  passed: boolean;
+  issues: SpecVerificationIssue[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function hasValueBinding(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const ref = value as Record<string, unknown>;
+  return (
+    typeof ref.$bindState === "string" || typeof ref.$bindItem === "string"
+  );
+}
+
+function hasEventBinding(element: UIElement, eventName: string): boolean {
+  const eventBinding = element.on?.[eventName];
+  if (!eventBinding) return false;
+  if (Array.isArray(eventBinding)) return eventBinding.length > 0;
+  return true;
+}
+
+function verifyRatingElement(
+  key: string,
+  element: UIElement,
+): SpecVerificationIssue[] {
+  const issues: SpecVerificationIssue[] = [];
+  const props = asRecord(element.props);
+  const rawValue = props.value;
+  const rawMax = props.max;
+  const value = typeof rawValue === "number" ? rawValue : null;
+  const max = typeof rawMax === "number" && rawMax > 0 ? rawMax : 5;
+
+  if (value !== null && (value < 0 || value > max)) {
+    issues.push({
+      severity: "error",
+      code: "rating_value_out_of_range",
+      elementKey: key,
+      message: `Rating "${key}" has value ${value} outside range 0-${max}.`,
+    });
+  }
+
+  const interactive = hasValueBinding(rawValue) || hasEventBinding(element, "change");
+  if (!interactive && value !== null) {
+    issues.push({
+      severity: "warning",
+      code: "rating_maybe_read_only",
+      elementKey: key,
+      message: `Rating "${key}" appears read-only (static value with no binding or on.change).`,
+    });
+  }
+
+  return issues;
+}
+
+function verifyChoiceElement(
+  key: string,
+  element: UIElement,
+  type: "Select" | "Radio",
+): SpecVerificationIssue[] {
+  const issues: SpecVerificationIssue[] = [];
+  const props = asRecord(element.props);
+  const rawOptions = props.options;
+
+  if (!Array.isArray(rawOptions)) {
+    issues.push({
+      severity: "error",
+      code: "choice_options_not_array",
+      elementKey: key,
+      message: `${type} "${key}" has invalid options. Expected an array.`,
+    });
+    return issues;
+  }
+
+  const normalized = normalizeChoiceOptions(rawOptions);
+
+  if (normalized.invalidCount > 0) {
+    issues.push({
+      severity: "error",
+      code: "choice_invalid_option_shape",
+      elementKey: key,
+      message: `${type} "${key}" has ${normalized.invalidCount} option(s) with unsupported shape.`,
+    });
+  }
+
+  if (normalized.objectCount > 0) {
+    issues.push({
+      severity: "warning",
+      code: "choice_object_options_detected",
+      elementKey: key,
+      message: `${type} "${key}" uses object options. Verify labels/values are correct.`,
+    });
+  }
+
+  const value = props.value;
+  if (
+    typeof value === "string" &&
+    value.length > 0 &&
+    normalized.options.length > 0 &&
+    !normalized.options.some((option) => option.value === value)
+  ) {
+    issues.push({
+      severity: "warning",
+      code: "choice_value_not_in_options",
+      elementKey: key,
+      message: `${type} "${key}" has value "${value}" that does not match any option.`,
+    });
+  }
+
+  return issues;
+}
+
+export function verifyPlaygroundSpec(spec: Spec): SpecVerificationResult {
+  const issues: SpecVerificationIssue[] = [];
+
+  const structural = validateSpec(spec);
+  for (const issue of structural.issues) {
+    issues.push({
+      severity: issue.severity,
+      code: "structural_issue",
+      message: issue.message,
+      elementKey: issue.elementKey,
+    });
+  }
+
+  for (const [key, element] of Object.entries(spec.elements)) {
+    if (element.type === "Rating") {
+      issues.push(...verifyRatingElement(key, element));
+      continue;
+    }
+
+    if (element.type === "Select" || element.type === "Radio") {
+      issues.push(...verifyChoiceElement(key, element, element.type));
+    }
+  }
+
+  const hasErrors = issues.some((issue) => issue.severity === "error");
+  return {
+    passed: !hasErrors,
+    issues,
+  };
+}
+
+export function buildVerificationFixPrompt(options: {
+  originalPrompt: string;
+  issues: SpecVerificationIssue[];
+}): string {
+  const { originalPrompt, issues } = options;
+  const lines = [
+    `Fix the current generated UI spec to satisfy this request: "${originalPrompt}".`,
+    "Keep layout/content intent, but repair invalid or non-interactive parts.",
+    "Verification issues to fix:",
+    ...issues.map((issue) => {
+      const keyLabel = issue.elementKey ? ` (${issue.elementKey})` : "";
+      return `- [${issue.severity}] ${issue.code}${keyLabel}: ${issue.message}`;
+    }),
+    "Required output format: JSONL patch operations only.",
+    "Important constraints:",
+    "- Rating used as user input must be interactive (bind value to state and handle on.change).",
+    "- Select/Radio options must be plain strings or valid {label, value} objects.",
+  ];
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
  This PR fixes generation reliability issues reported in #129 and adds a quick verification + feedback step in the
  playground after generation.

  ## Problems
  - Generated `Rating` could become read-only in feedback/form scenarios.
  - Generated `Select/Radio` options could render as `[object Object]`.
  - No quick post-generation verification/feedback loop for users.

  ## Changes
  - Made `Rating` interactive in playground registry (state binding + `on.change` support).
  - Added option normalization for `Select/Radio` to handle object-shaped options safely.
  - Added spec verification module (structural + semantic checks).
  - Added verification panel in playground with actions:
    - `Looks good`
    - `Fix issues` (regenerate with issue-aware repair prompt)
    - `Regenerate`
  - Tightened generation prompt rules for interactive rating and select/radio option shape.
  - Updated README with verification capability note.

  ## Validation
  - Ran `pnpm type-check` successfully.