### PR TITLE
fix: resolve Array<unknown> issue for array props in Catalog prompt generation

### DIFF
--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -169,7 +169,11 @@ describe("catalog.prompt", () => {
     const catalog = defineCatalog(testSchema, {
       components: {
         Card: {
-          props: z.object({ title: z.string() }),
+          props: z.object({
+            title: z.string(),
+            names: z.array(z.string()),
+            users: z.array(z.object({ name: z.string(), age: z.number() })),
+          }),
           description: "A card container",
           slots: ["default"],
         },
@@ -180,6 +184,9 @@ describe("catalog.prompt", () => {
     expect(prompt).toContain("AVAILABLE COMPONENTS");
     expect(prompt).toContain("Card");
     expect(prompt).toContain("A card container");
+    expect(prompt).toContain("title: string");
+    expect(prompt).toContain("names: Array<string>");
+    expect(prompt).toContain("users: Array<{ name: string, age: number }>");
   });
 
   it("includes AVAILABLE ACTIONS when present", () => {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1188,7 +1188,14 @@ function formatZodType(schema: z.ZodType): string {
     }
     case "ZodArray":
     case "array": {
-      const inner = (def.type as z.ZodType) ?? (def.element as z.ZodType);
+      // safely resolve inner type for Zod arrays
+      const inner = (
+        typeof def.element === "object"
+          ? def.element
+          : typeof def.type === "object"
+            ? def.type
+            : undefined
+      ) as z.ZodType | undefined;
       return inner ? `Array<${formatZodType(inner)}>` : "Array<unknown>";
     }
     case "ZodObject":


### PR DESCRIPTION
## Description
This PR fixes an issue where array-type properties defined in a component's `Catalog` are incorrectly parsed during prompt generation, causing them to always be displayed as `Array<unknown>` in the `AVAILABLE COMPONENTS` section of the AI prompt.

**The Bug:**
When defining a component property as an array (e.g., in `catalog.ts`), the `formatZodType` function receives a definition where `def.element` or `def.type` might not be a valid Zod schema object directly. The previous assignment `const inner = def.type ?? def.element;` failed to recursively resolve the inner schema correctly, leading it to fall back to `"Array<unknown>"`.

**The Fix:**
Added a safety check `typeof === 'object'` when extracting `def.element` or `def.type` for `ZodArray` types. This ensures the inner type is safely passed to the recursive `formatZodType` call, properly generating strings like `Array<string>` or `Array<object>` instead of `Array<unknown>`.

## Changes
- Updated the `array` / `ZodArray` case in `formatZodType` to safely resolve the inner schema.
- **Updated unit tests** to verify that the `AVAILABLE COMPONENTS` prompt correctly generates specific array types (e.g., `Array<string>`) instead of falling back to `Array<unknown>`.