### PR TITLE
fix schema import to use server-safe subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ json-render is a **Generative UI** framework: AI generates interfaces from natur
 
 ```typescript
 import { defineCatalog } from "@json-render/core";
-import { schema } from "@json-render/react";
+import { schema } from "@json-render/react/schema";
 import { z } from "zod";
 
 const catalog = defineCatalog(schema, {
@@ -124,7 +124,7 @@ function Dashboard({ spec }) {
 
 ```tsx
 import { defineRegistry, Renderer } from "@json-render/react";
-import { schema } from "@json-render/react";
+import { schema } from "@json-render/react/schema";
 
 // Flat spec format (root key + elements map)
 const spec = {
@@ -152,7 +152,8 @@ const { registry } = defineRegistry(catalog, { components });
 
 ```tsx
 import { defineCatalog } from "@json-render/core";
-import { schema, defineRegistry, Renderer } from "@json-render/react";
+import { schema } from "@json-render/react/schema";
+import { defineRegistry, Renderer } from "@json-render/react";
 import { shadcnComponentDefinitions } from "@json-render/shadcn/catalog";
 import { shadcnComponents } from "@json-render/shadcn";
 

--- a/apps/web/app/(main)/docs/a2ui/page.mdx
+++ b/apps/web/app/(main)/docs/a2ui/page.mdx
@@ -67,7 +67,7 @@ A2UI uses an adjacency list model - a flat list of components with ID references
 
 ```typescript
 import { defineCatalog } from '@json-render/core';
-import { schema } from '@json-render/react';
+import { schema } from '@json-render/react/schema';
 import { z } from 'zod';
 
 // A2UI BoundValue schema

--- a/apps/web/app/(main)/docs/adaptive-cards/page.mdx
+++ b/apps/web/app/(main)/docs/adaptive-cards/page.mdx
@@ -90,7 +90,7 @@ Define a catalog matching the Adaptive Cards element types:
 
 ```typescript
 import { defineCatalog } from '@json-render/core';
-import { schema } from '@json-render/react';
+import { schema } from '@json-render/react/schema';
 import { z } from 'zod';
 
 // Common Adaptive Cards properties

--- a/apps/web/app/(main)/docs/ag-ui/page.mdx
+++ b/apps/web/app/(main)/docs/ag-ui/page.mdx
@@ -151,7 +151,7 @@ Create a catalog for UI components that agents can render:
 
 ```typescript
 import { defineCatalog } from '@json-render/core';
-import { schema } from '@json-render/react';
+import { schema } from '@json-render/react/schema';
 import { z } from 'zod';
 
 export const aguiCatalog = defineCatalog(schema, {

--- a/apps/web/app/(main)/docs/api/core/page.mdx
+++ b/apps/web/app/(main)/docs/api/core/page.mdx
@@ -11,7 +11,7 @@ Creates a type-safe catalog definition with schema validation.
 
 ```typescript
 import { defineCatalog } from '@json-render/core';
-import { schema } from '@json-render/react';
+import { schema } from '@json-render/react/schema';
 
 function defineCatalog<T extends ZodType>(
   s: T,
@@ -119,7 +119,7 @@ The schema for flat UI element trees. This is exported from @json-render/react.
 
 ```typescript
 import { defineCatalog } from '@json-render/core';
-import { schema } from '@json-render/react';
+import { schema } from '@json-render/react/schema';
 
 // schema defines:
 // - Spec shape: { root: string, elements: Record<string, UIElement> }

--- a/apps/web/app/(main)/docs/catalog/page.mdx
+++ b/apps/web/app/(main)/docs/catalog/page.mdx
@@ -19,7 +19,7 @@ A catalog is the vocabulary for your UI. While the [schema](/docs/schemas) defin
 
 ```typescript
 import { defineCatalog } from '@json-render/core';
-import { schema } from '@json-render/react'; // or '@json-render/react-native'
+import { schema } from '@json-render/react/schema'; // or '@json-render/react-native/schema'
 import { z } from 'zod';
 
 const catalog = defineCatalog(schema, {

--- a/apps/web/app/(main)/docs/openapi/page.mdx
+++ b/apps/web/app/(main)/docs/openapi/page.mdx
@@ -100,7 +100,7 @@ Create components that map to OpenAPI data types:
 
 ```typescript
 import { defineCatalog } from '@json-render/core';
-import { schema } from '@json-render/react';
+import { schema } from '@json-render/react/schema';
 import { z } from 'zod';
 
 export const openapiCatalog = defineCatalog(schema, {

--- a/apps/web/app/(main)/docs/page.mdx
+++ b/apps/web/app/(main)/docs/page.mdx
@@ -23,7 +23,7 @@ A catalog declares what AI can use: components with typed props, actions with ty
 
 ```typescript
 import { defineCatalog } from '@json-render/core';
-import { schema } from '@json-render/react';
+import { schema } from '@json-render/react/schema';
 import { z } from 'zod';
 
 export const catalog = defineCatalog(schema, {

--- a/apps/web/app/(main)/docs/quick-start/page.mdx
+++ b/apps/web/app/(main)/docs/quick-start/page.mdx
@@ -12,7 +12,7 @@ Create a catalog that defines what components AI can use:
 ```typescript
 // lib/catalog.ts
 import { defineCatalog } from '@json-render/core';
-import { schema } from '@json-render/react';
+import { schema } from '@json-render/react/schema';
 import { z } from 'zod';
 
 export const catalog = defineCatalog(schema, {

--- a/apps/web/app/(main)/docs/registry/page.mdx
+++ b/apps/web/app/(main)/docs/registry/page.mdx
@@ -133,7 +133,7 @@ Actions are declared in your [catalog](/docs/catalog). The `@json-render/react` 
 
 ```typescript
 import { defineCatalog } from '@json-render/core';
-import { schema } from '@json-render/react';
+import { schema } from '@json-render/react/schema';
 import { z } from 'zod';
 
 const catalog = defineCatalog(schema, {

--- a/apps/web/app/(main)/docs/validation/page.mdx
+++ b/apps/web/app/(main)/docs/validation/page.mdx
@@ -67,7 +67,7 @@ Define custom validators in your catalog's `functions` field. The catalog itself
 
 ```typescript
 import { defineCatalog } from '@json-render/core';
-import { schema } from '@json-render/react'; // or '@json-render/react-native'
+import { schema } from '@json-render/react/schema'; // or '@json-render/react-native/schema'
 import { z } from 'zod';
 
 const catalog = defineCatalog(schema, {

--- a/examples/stripe-app/drawer-app/src/lib/render/catalog.ts
+++ b/examples/stripe-app/drawer-app/src/lib/render/catalog.ts
@@ -1,5 +1,5 @@
 import { defineCatalog } from "@json-render/core";
-import { schema } from "@json-render/react";
+import { schema } from "@json-render/react/schema";
 import { z } from "zod";
 
 /**

--- a/examples/stripe-app/fullpage-app/src/lib/render/catalog.ts
+++ b/examples/stripe-app/fullpage-app/src/lib/render/catalog.ts
@@ -1,5 +1,5 @@
 import { defineCatalog } from "@json-render/core";
-import { schema } from "@json-render/react";
+import { schema } from "@json-render/react/schema";
 import { z } from "zod";
 
 /**

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -14,7 +14,7 @@ npm install @json-render/react @json-render/core zod
 
 ```typescript
 import { defineCatalog } from "@json-render/core";
-import { schema } from "@json-render/react";
+import { schema } from "@json-render/react/schema";
 import { z } from "zod";
 
 export const catalog = defineCatalog(schema, {
@@ -409,7 +409,8 @@ const systemPrompt = catalog.prompt();
 
 ```tsx
 import { defineCatalog } from "@json-render/core";
-import { schema, defineRegistry, Renderer } from "@json-render/react";
+import { schema } from "@json-render/react/schema";
+import { defineRegistry, Renderer } from "@json-render/react";
 import { z } from "zod";
 
 const catalog = defineCatalog(schema, {

--- a/skills/json-render-react/SKILL.md
+++ b/skills/json-render-react/SKILL.md
@@ -28,7 +28,8 @@ function App({ spec }) {
 
 ```typescript
 import { defineCatalog } from "@json-render/core";
-import { schema, defineRegistry } from "@json-render/react";
+import { schema } from "@json-render/react/schema";
+import { defineRegistry } from "@json-render/react";
 import { z } from "zod";
 
 // Create catalog with props schemas


### PR DESCRIPTION
- `@json-render/react` barrel-imports React contexts that call `createContext`, which crashes in Next.js App Router API routes (RSC runtime strips `createContext`)
- Updated all docs, READMEs, examples, and skills to import `schema` from `@json-render/react/schema` instead of `@json-render/react`
- For combined imports, split into separate `schema` (subpath) and client API (main entry) lines

Fixes #123