### PR TITLE
Fix turbo dev concurrency for persistent tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev --concurrency 20",
+    "dev": "turbo run dev --concurrency 23",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "type-check": "turbo run check-types",


### PR DESCRIPTION
Raises root dev concurrency from 20 to 23 to match current persistent task count and prevent startup failure when running pnpm dev.