### PR TITLE
chore: release v0.12.1 - update package versions and changelogs

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # web
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/codegen@0.12.1
+  - @json-render/react@0.12.1
+
 ## 0.1.5
 
 ### Patch Changes

--- a/apps/web/app/(main)/docs/changelog/page.mdx
+++ b/apps/web/app/(main)/docs/changelog/page.mdx
@@ -5,6 +5,29 @@ export const metadata = pageMetadata("docs/changelog")
 
 Notable changes and updates to json-render.
 
+## v0.12.1
+
+March 2026
+
+### Changed: Generation Mode Names
+
+The generation mode values passed to `catalog.prompt()` have been renamed for clarity:
+
+- `"generate"` is now `"standalone"`
+- `"chat"` is now `"inline"`
+
+The old names are accepted as deprecated aliases and will emit a console warning. See the [Migration Guide](/docs/migration#generation-modes) for details.
+
+### Fixed: MCP React Duplicate Module Error
+
+Resolved a React duplicate module error in `@json-render/mcp` by adding Vite dedupe configuration. Also added a new `@json-render/mcp/build-app-html` server-safe entry point for building self-contained MCP App HTML without importing React.
+
+### Improved: Skill Names
+
+Skills have been renamed from `json-render-*` to shorter names (e.g. `json-render-react` → `react`, `json-render-core` → `core`).
+
+---
+
 ## v0.10.0
 
 February 2026

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "private": true,
   "license": "Apache-2.0",

--- a/examples/chat/CHANGELOG.md
+++ b/examples/chat/CHANGELOG.md
@@ -1,5 +1,14 @@
 # example-chat
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/react@0.12.1
+  - @json-render/shadcn@0.12.1
+
 ## 0.1.5
 
 ### Patch Changes

--- a/examples/chat/package.json
+++ b/examples/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-chat",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "private": true,
   "scripts": {

--- a/examples/dashboard/CHANGELOG.md
+++ b/examples/dashboard/CHANGELOG.md
@@ -1,5 +1,14 @@
 # example-dashboard
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/codegen@0.12.1
+  - @json-render/react@0.12.1
+
 ## 0.1.5
 
 ### Patch Changes

--- a/examples/dashboard/package.json
+++ b/examples/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-dashboard",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "private": true,
   "scripts": {

--- a/examples/image/CHANGELOG.md
+++ b/examples/image/CHANGELOG.md
@@ -1,5 +1,13 @@
 # example-image
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/image@0.12.1
+
 ## 0.1.2
 
 ### Patch Changes

--- a/examples/image/package.json
+++ b/examples/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-image",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "private": true,
   "scripts": {

--- a/examples/mcp/CHANGELOG.md
+++ b/examples/mcp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # example-mcp
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/mcp@0.12.1
+  - @json-render/react@0.12.1
+  - @json-render/shadcn@0.12.1
+
 ## 0.1.1
 
 ### Patch Changes

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "private": true,
   "scripts": {

--- a/examples/no-ai/CHANGELOG.md
+++ b/examples/no-ai/CHANGELOG.md
@@ -1,5 +1,14 @@
 # example-no-ai
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/react@0.12.1
+  - @json-render/shadcn@0.12.1
+
 ## 0.1.5
 
 ### Patch Changes

--- a/examples/no-ai/package.json
+++ b/examples/no-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-no-ai",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "private": true,
   "scripts": {

--- a/examples/react-email/CHANGELOG.md
+++ b/examples/react-email/CHANGELOG.md
@@ -1,5 +1,13 @@
 # example-react-email
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/react-email@0.12.1
+
 ## 0.1.1
 
 ### Patch Changes

--- a/examples/react-email/package.json
+++ b/examples/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-react-email",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "private": true,
   "scripts": {

--- a/examples/react-native/CHANGELOG.md
+++ b/examples/react-native/CHANGELOG.md
@@ -1,5 +1,13 @@
 # example-react-native
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/react-native@0.12.1
+
 ## 0.1.5
 
 ### Patch Changes

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-react-native",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/examples/react-pdf/CHANGELOG.md
+++ b/examples/react-pdf/CHANGELOG.md
@@ -1,5 +1,13 @@
 # example-react-pdf
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/react-pdf@0.12.1
+
 ## 0.1.5
 
 ### Patch Changes

--- a/examples/react-pdf/package.json
+++ b/examples/react-pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-react-pdf",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "private": true,
   "scripts": {

--- a/examples/remotion/CHANGELOG.md
+++ b/examples/remotion/CHANGELOG.md
@@ -1,5 +1,13 @@
 # example-remotion
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/remotion@0.12.1
+
 ## 0.1.5
 
 ### Patch Changes

--- a/examples/remotion/package.json
+++ b/examples/remotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-remotion",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "private": true,
   "scripts": {

--- a/examples/stripe-app/drawer-app/CHANGELOG.md
+++ b/examples/stripe-app/drawer-app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # com.example.json-render-demo
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/react@0.12.1
+
 ## 0.0.6
 
 ### Patch Changes

--- a/examples/stripe-app/drawer-app/package.json
+++ b/examples/stripe-app/drawer-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.example.json-render-demo",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Test",
   "private": true,
   "license": "~~proprietary~~",

--- a/examples/stripe-app/fullpage-app/CHANGELOG.md
+++ b/examples/stripe-app/fullpage-app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # com.example.json-render-fullpage-demo
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/react@0.12.1
+
 ## 0.0.6
 
 ### Patch Changes

--- a/examples/stripe-app/fullpage-app/package.json
+++ b/examples/stripe-app/fullpage-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.example.json-render-fullpage-demo",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Full-page Stripe App example (alpha)",
   "private": true,
   "license": "~~proprietary~~",

--- a/examples/svelte-chat/CHANGELOG.md
+++ b/examples/svelte-chat/CHANGELOG.md
@@ -1,5 +1,13 @@
 # svelte-chat
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/svelte@0.12.1
+
 ## 0.0.2
 
 ### Patch Changes

--- a/examples/svelte-chat/package.json
+++ b/examples/svelte-chat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-chat",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/examples/svelte/CHANGELOG.md
+++ b/examples/svelte/CHANGELOG.md
@@ -1,5 +1,13 @@
 # example-svelte
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/svelte@0.12.1
+
 ## 0.1.2
 
 ### Patch Changes

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-svelte",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/vite-renderers/CHANGELOG.md
+++ b/examples/vite-renderers/CHANGELOG.md
@@ -1,5 +1,15 @@
 # vite-renderers
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/react@0.12.1
+  - @json-render/svelte@0.12.1
+  - @json-render/vue@0.12.1
+
 ## 0.1.3
 
 ### Patch Changes

--- a/examples/vite-renderers/package.json
+++ b/examples/vite-renderers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-renderers",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/vue/CHANGELOG.md
+++ b/examples/vue/CHANGELOG.md
@@ -1,5 +1,13 @@
 # example-vue
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/vue@0.12.1
+
 ## 0.1.3
 
 ### Patch Changes

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-vue",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "scripts": {
     "predev": "command -v portless >/dev/null 2>&1 || (echo '\\nportless is required but not installed. Run: npm i -g portless\\nSee: https://github.com/vercel-labs/portless\\n' && exit 1)",

--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/codegen
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/codegen",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "Utilities for generating code from json-render UI trees",
   "keywords": [

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @json-render/core
 
+## 0.12.1
+
+### Patch Changes
+
+- Rename generation modes and fix MCP React duplicate module error.
+
+  ### Changed:
+  - **`@json-render/core`** — Renamed generation modes: `"generate"` is now `"standalone"`, `"chat"` is now `"inline"`. The old names are still accepted but emit a deprecation warning.
+
+  ### Fixed:
+  - **`@json-render/mcp`** — Resolved React duplicate module error by adding Vite dedupe config. Added new `@json-render/mcp/build-app-html` server-safe entry point for building self-contained MCP App HTML without importing React.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/core",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "JSON becomes real things. Define your catalog, register your components, let AI generate.",
   "keywords": [

--- a/packages/image/CHANGELOG.md
+++ b/packages/image/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/image
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/image",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "Image renderer for @json-render/core. JSON becomes SVG and PNG images via Satori.",
   "keywords": [

--- a/packages/jotai/CHANGELOG.md
+++ b/packages/jotai/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/jotai
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/jotai/package.json
+++ b/packages/jotai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/jotai",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "Jotai adapter for json-render StateStore",
   "keywords": [

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @json-render/mcp
 
+## 0.12.1
+
+### Patch Changes
+
+- Rename generation modes and fix MCP React duplicate module error.
+
+  ### Changed:
+  - **`@json-render/core`** — Renamed generation modes: `"generate"` is now `"standalone"`, `"chat"` is now `"inline"`. The old names are still accepted but emit a deprecation warning.
+
+  ### Fixed:
+  - **`@json-render/mcp`** — Resolved React duplicate module error by adding Vite dedupe config. Added new `@json-render/mcp/build-app-html` server-safe entry point for building self-contained MCP App HTML without importing React.
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/mcp",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "MCP Apps integration for @json-render/core. Serve json-render UIs as interactive MCP Apps in Claude, ChatGPT, Cursor, and VS Code.",
   "keywords": [

--- a/packages/react-email/CHANGELOG.md
+++ b/packages/react-email/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/react-email
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-email",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "React Email renderer for @json-render/core. JSON becomes HTML emails.",
   "keywords": [

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/react-native
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-native",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "React Native renderer for @json-render/core. JSON becomes React Native components.",
   "keywords": [

--- a/packages/react-pdf/CHANGELOG.md
+++ b/packages/react-pdf/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/react-pdf
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-pdf",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "React PDF renderer for @json-render/core. JSON becomes PDF documents.",
   "keywords": [

--- a/packages/react-state/CHANGELOG.md
+++ b/packages/react-state/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @internal/react-state
 
+## 0.8.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.8.5
 
 ### Patch Changes

--- a/packages/react-state/package.json
+++ b/packages/react-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internal/react-state",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "license": "Apache-2.0",
   "description": "Shared React state context for json-render renderer packages",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/react
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "React renderer for @json-render/core. JSON becomes React components.",
   "keywords": [

--- a/packages/redux/CHANGELOG.md
+++ b/packages/redux/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/redux
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/redux",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "Redux adapter for json-render StateStore",
   "keywords": [

--- a/packages/remotion/CHANGELOG.md
+++ b/packages/remotion/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/remotion
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/remotion/package.json
+++ b/packages/remotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/remotion",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "Remotion renderer for @json-render/core. JSON becomes video compositions.",
   "keywords": [

--- a/packages/shadcn/CHANGELOG.md
+++ b/packages/shadcn/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @json-render/shadcn
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+  - @json-render/react@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/shadcn",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "shadcn/ui component library for @json-render/core. JSON becomes beautiful Tailwind-styled React components.",
   "keywords": [

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/svelte
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/svelte",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "Svelte 5 renderer for @json-render/core. JSON becomes Svelte components.",
   "keywords": [

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/vue
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/vue",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "Vue renderer for @json-render/core. JSON becomes Vue components.",
   "keywords": [

--- a/packages/xstate/CHANGELOG.md
+++ b/packages/xstate/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/xstate
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/xstate/package.json
+++ b/packages/xstate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/xstate",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "XState Store adapter for json-render StateStore",
   "keywords": [

--- a/packages/zustand/CHANGELOG.md
+++ b/packages/zustand/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @json-render/zustand
 
+## 0.12.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @json-render/core@0.12.1
+
 ## 0.12.0
 
 ### Patch Changes

--- a/packages/zustand/package.json
+++ b/packages/zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/zustand",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "Zustand adapter for json-render StateStore",
   "keywords": [


### PR DESCRIPTION
This PR prepares the v0.12.1 release by updating package versions and changelogs across all packages, examples, and apps in the monorepo.

## Changes Made

- **Version Bumps**: Updated all package.json files from v0.12.0 to v0.12.1 across:
  - 18 core packages (core, react, vue, svelte, etc.)
  - 16 example applications
  - Web documentation app

- **Changelog Updates**: Added v0.12.1 entries to all CHANGELOG.md files documenting:
  - Generation mode rename: `"generate"` → `"standalone"`, `"chat"` → `"inline"`
  - Fixed React duplicate module error in `@json-render/mcp`
  - Improved skill names (shortened from `json-render-*` format)
  - Updated dependency references

- **Documentation**: Updated the changelog page with detailed migration information for the generation mode changes

This is a coordinated release across the entire monorepo to maintain version consistency and provide users with the latest improvements and bug fixes.

Fixes #198