### PR TITLE
Add v0.12.1 release changeset with mode renames and MCP fixes

### DIFF
--- a/.changeset/v0-12-1-release.md
+++ b/.changeset/v0-12-1-release.md
@@ -1,0 +1,20 @@
+---
+"@json-render/core": patch
+"@json-render/mcp": patch
+---
+
+Rename generation modes and fix MCP React duplicate module error.
+
+### Changed:
+
+- **`@json-render/core`** — Renamed generation modes from `"generate"` / `"chat"` to `"standalone"` / `"inline"`. The old names still work but emit a deprecation warning.
+
+### Fixed:
+
+- **`@json-render/mcp`** — Resolved React duplicate module error (`useRef` returning null) by adding `resolve.dedupe` Vite configuration. Added `./build-app-html` export entry point.
+
+### Other:
+
+- Updated `homepage` URLs across all packages to point to `https://json-render.dev`.
+- Reorganized skills directory structure for cleaner naming.
+- Added skills documentation page to the web app.


### PR DESCRIPTION
This PR adds the changeset file to prepare for the v0.12.1 release, documenting important breaking changes and bug fixes.

## Changes

**@json-render/core**
- Renamed generation modes from `"generate"`/`"chat"` to `"standalone"`/`"inline"` (old names deprecated with warnings)

**@json-render/mcp**  
- Fixed React duplicate module error causing `useRef` to return null by adding Vite `resolve.dedupe` configuration
- Added `./build-app-html` export entry point

**Other improvements**
- Updated homepage URLs across all packages to https://json-render.dev
- Reorganized skills directory structure
- Added skills documentation page to web app

Fixes #198