### PR TITLE
fix(core): add truncation recovery to parseSpecStreamLine

### DIFF
--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -12,9 +12,92 @@ import {
   createSpecStreamCompiler,
   createMixedStreamParser,
   createJsonRenderTransform,
+  parseSpecStreamLine,
   SPEC_DATA_PART_TYPE,
 } from "./types";
 import type { Spec, SpecStreamLine, StreamChunk } from "./types";
+
+// =============================================================================
+// parseSpecStreamLine - including truncation recovery
+// =============================================================================
+
+describe("parseSpecStreamLine", () => {
+  it("parses valid JSON patch operations", () => {
+    const result = parseSpecStreamLine(
+      '{"op":"add","path":"/root","value":"main"}',
+    );
+    expect(result).toEqual({ op: "add", path: "/root", value: "main" });
+  });
+
+  it("returns null for empty input", () => {
+    expect(parseSpecStreamLine("")).toBeNull();
+    expect(parseSpecStreamLine("   ")).toBeNull();
+  });
+
+  it("returns null for non-JSON input", () => {
+    expect(parseSpecStreamLine("hello world")).toBeNull();
+    expect(parseSpecStreamLine("not json")).toBeNull();
+  });
+
+  it("returns null for JSON without op field", () => {
+    expect(parseSpecStreamLine('{"path":"/root","value":"x"}')).toBeNull();
+  });
+
+  it("returns null for JSON without path field", () => {
+    expect(parseSpecStreamLine('{"op":"add","value":"x"}')).toBeNull();
+  });
+
+  describe("truncation recovery", () => {
+    it("repairs truncated JSON missing closing brace", () => {
+      const result = parseSpecStreamLine(
+        '{"op":"add","path":"/root","value":"main"',
+      );
+      expect(result).toEqual({ op: "add", path: "/root", value: "main" });
+    });
+
+    it("repairs truncated JSON missing closing bracket and brace", () => {
+      const result = parseSpecStreamLine(
+        '{"op":"add","path":"/items","value":[1,2,3]',
+      );
+      expect(result).toEqual({ op: "add", path: "/items", value: [1, 2, 3] });
+    });
+
+    it("repairs deeply nested truncated JSON", () => {
+      const result = parseSpecStreamLine(
+        '{"op":"add","path":"/el","value":{"type":"Card","props":{"title":"Hi"},"children":[]',
+      );
+      expect(result).toEqual({
+        op: "add",
+        path: "/el",
+        value: { type: "Card", props: { title: "Hi" }, children: [] },
+      });
+    });
+
+    it("repairs truncated JSON with unclosed string", () => {
+      const result = parseSpecStreamLine(
+        '{"op":"add","path":"/root","value":"main',
+      );
+      expect(result).toEqual({ op: "add", path: "/root", value: "main" });
+    });
+
+    it("repairs truncated array inside value", () => {
+      const result = parseSpecStreamLine(
+        '{"op":"add","path":"/arr","value":["a","b"',
+      );
+      expect(result).toEqual({ op: "add", path: "/arr", value: ["a", "b"] });
+    });
+
+    it("returns null for truly malformed JSON (mismatched brackets)", () => {
+      expect(parseSpecStreamLine('{"op":"add"]')).toBeNull();
+      expect(parseSpecStreamLine('{"op":"add","value":[}')).toBeNull();
+    });
+
+    it("returns null for incomplete patch without required fields", () => {
+      // Even if repaired, missing required fields = null
+      expect(parseSpecStreamLine('{"op":"add"')).toBeNull();
+    });
+  });
+});
 
 describe("getByPath", () => {
   it("gets nested values with JSON pointer paths", () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -552,13 +552,35 @@ export type SpecStreamLine = JsonPatch;
  *
  * SpecStream is json-render's streaming format where each line is a JSON patch
  * operation that progressively builds up the final spec.
+ *
+ * Includes truncation recovery: if JSON.parse fails, attempts to repair
+ * truncated JSON by closing unclosed brackets/braces before giving up.
  */
 export function parseSpecStreamLine(line: string): SpecStreamLine | null {
   const trimmed = line.trim();
   if (!trimmed || !trimmed.startsWith("{")) return null;
 
+  // First, try parsing as-is
+  const parsed = tryParseJsonPatch(trimmed);
+  if (parsed) return parsed;
+
+  // Attempt truncation recovery: close unclosed brackets/braces
+  const repaired = attemptJsonRepair(trimmed);
+  if (repaired && repaired !== trimmed) {
+    const repairedParsed = tryParseJsonPatch(repaired);
+    if (repairedParsed) return repairedParsed;
+  }
+
+  return null;
+}
+
+/**
+ * Try to parse a string as a JSON patch operation.
+ * Returns the patch if valid, null otherwise.
+ */
+function tryParseJsonPatch(str: string): SpecStreamLine | null {
   try {
-    const patch = JSON.parse(trimmed) as SpecStreamLine;
+    const patch = JSON.parse(str) as SpecStreamLine;
     if (patch.op && patch.path !== undefined) {
       return patch;
     }
@@ -566,6 +588,73 @@ export function parseSpecStreamLine(line: string): SpecStreamLine | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Attempt to repair truncated JSON by closing unclosed brackets and braces.
+ * Only handles simple truncation cases where the JSON was cut off mid-stream.
+ *
+ * @example
+ * '{"op":"add","path":"/root","value":"main"' -> '{"op":"add","path":"/root","value":"main"}'
+ * '{"op":"add","path":"/items","value":[1,2' -> '{"op":"add","path":"/items","value":[1,2]}'
+ */
+function attemptJsonRepair(str: string): string | null {
+  // Track unclosed brackets/braces (ignoring those inside strings)
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i]!;
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) continue;
+
+    if (char === "{" || char === "[") {
+      stack.push(char);
+    } else if (char === "}") {
+      if (stack.length === 0 || stack[stack.length - 1] !== "{") {
+        return null; // Malformed, not just truncated
+      }
+      stack.pop();
+    } else if (char === "]") {
+      if (stack.length === 0 || stack[stack.length - 1] !== "[") {
+        return null; // Malformed, not just truncated
+      }
+      stack.pop();
+    }
+  }
+
+  // If nothing is unclosed, the JSON is complete (but invalid for other reasons)
+  if (stack.length === 0) return null;
+
+  // If we're mid-string, close the string first
+  let repaired = str;
+  if (inString) {
+    repaired += '"';
+  }
+
+  // Close unclosed brackets/braces in reverse order
+  while (stack.length > 0) {
+    const opener = stack.pop()!;
+    repaired += opener === "{" ? "}" : "]";
+  }
+
+  return repaired;
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses #196

When LLM responses are truncated mid-stream, `parseSpecStreamLine` now attempts to repair the JSON by closing unclosed brackets, braces, and strings before giving up.

## Problem

During streaming scenarios, network issues or model interruptions can cause incomplete JSON patches like:

```json
{"op":"add","path":"/root","value":"main"
```

Previously, these would silently fail with no recovery attempt.

## Solution

Added `attemptJsonRepair()` helper that:
1. Tracks unclosed brackets/braces (respecting string boundaries)
2. Closes unclosed strings first
3. Closes remaining brackets/braces in reverse order

### Recovery handles:
- Missing closing braces: `{"op":"add"...` → adds `}`
- Missing closing brackets: `[1,2,3` → adds `]`
- Unclosed strings: `"value":"hello` → adds `"`
- Nested structures: handles multiple levels

Returns `null` for truly malformed JSON (mismatched brackets) to avoid false positives.

## Testing

Added comprehensive test suite covering:
- Valid JSON parsing (unchanged behavior)
- Truncation recovery scenarios
- Edge cases (malformed vs truncated)

## Checklist

- [x] Tests added
- [x] No breaking changes
- [x] Documentation updated (JSDoc comments)