### PR TITLE
feat(core): add between and lengthBetween validation functions

### DIFF
--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -135,6 +135,91 @@ describe("builtInValidationFunctions", () => {
     });
   });
 
+  describe("between", () => {
+    it("passes when number is within range", () => {
+      expect(builtInValidationFunctions.between(5, { min: 1, max: 10 })).toBe(
+        true,
+      );
+      expect(builtInValidationFunctions.between(1, { min: 1, max: 10 })).toBe(
+        true,
+      );
+      expect(builtInValidationFunctions.between(10, { min: 1, max: 10 })).toBe(
+        true,
+      );
+    });
+
+    it("fails when number is below range", () => {
+      expect(builtInValidationFunctions.between(0, { min: 1, max: 10 })).toBe(
+        false,
+      );
+    });
+
+    it("fails when number is above range", () => {
+      expect(builtInValidationFunctions.between(11, { min: 1, max: 10 })).toBe(
+        false,
+      );
+    });
+
+    it("fails for non-numbers", () => {
+      expect(builtInValidationFunctions.between("5", { min: 1, max: 10 })).toBe(
+        false,
+      );
+    });
+
+    it("fails when min or max is not provided", () => {
+      expect(builtInValidationFunctions.between(5, { min: 1 })).toBe(false);
+      expect(builtInValidationFunctions.between(5, { max: 10 })).toBe(false);
+      expect(builtInValidationFunctions.between(5, {})).toBe(false);
+    });
+  });
+
+  describe("lengthBetween", () => {
+    it("passes when string length is within range", () => {
+      expect(
+        builtInValidationFunctions.lengthBetween("hello", { min: 3, max: 10 }),
+      ).toBe(true);
+      expect(
+        builtInValidationFunctions.lengthBetween("abc", { min: 3, max: 10 }),
+      ).toBe(true);
+      expect(
+        builtInValidationFunctions.lengthBetween("abcdefghij", {
+          min: 3,
+          max: 10,
+        }),
+      ).toBe(true);
+    });
+
+    it("fails when string is too short", () => {
+      expect(
+        builtInValidationFunctions.lengthBetween("ab", { min: 3, max: 10 }),
+      ).toBe(false);
+    });
+
+    it("fails when string is too long", () => {
+      expect(
+        builtInValidationFunctions.lengthBetween("abcdefghijk", {
+          min: 3,
+          max: 10,
+        }),
+      ).toBe(false);
+    });
+
+    it("fails for non-strings", () => {
+      expect(
+        builtInValidationFunctions.lengthBetween(12345, { min: 3, max: 10 }),
+      ).toBe(false);
+    });
+
+    it("fails when min or max is not provided", () => {
+      expect(
+        builtInValidationFunctions.lengthBetween("hello", { min: 3 }),
+      ).toBe(false);
+      expect(
+        builtInValidationFunctions.lengthBetween("hello", { max: 10 }),
+      ).toBe(false);
+    });
+  });
+
   describe("numeric", () => {
     it("passes for numbers", () => {
       expect(builtInValidationFunctions.numeric(42)).toBe(true);
@@ -599,6 +684,38 @@ describe("check helper", () => {
 
       expect(c.type).toBe("max");
       expect(c.args).toEqual({ max: 100 });
+    });
+  });
+
+  describe("between", () => {
+    it("creates between check with args", () => {
+      const c = check.between(1, 100, "Out of range");
+
+      expect(c.type).toBe("between");
+      expect(c.args).toEqual({ min: 1, max: 100 });
+      expect(c.message).toBe("Out of range");
+    });
+
+    it("uses default message", () => {
+      const c = check.between(0, 10);
+
+      expect(c.message).toBe("Must be between 0 and 10");
+    });
+  });
+
+  describe("lengthBetween", () => {
+    it("creates lengthBetween check with args", () => {
+      const c = check.lengthBetween(3, 50, "Invalid length");
+
+      expect(c.type).toBe("lengthBetween");
+      expect(c.args).toEqual({ min: 3, max: 50 });
+      expect(c.message).toBe("Invalid length");
+    });
+
+    it("uses default message", () => {
+      const c = check.lengthBetween(5, 100);
+
+      expect(c.message).toBe("Must be between 5 and 100 characters");
     });
   });
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -149,6 +149,30 @@ export const builtInValidationFunctions: Record<string, ValidationFunction> = {
   },
 
   /**
+   * Check if numeric value is within a range (inclusive).
+   * Combines min and max checks in a single validation.
+   */
+  between: (value: unknown, args?: Record<string, unknown>) => {
+    if (typeof value !== "number") return false;
+    const min = args?.min;
+    const max = args?.max;
+    if (typeof min !== "number" || typeof max !== "number") return false;
+    return value >= min && value <= max;
+  },
+
+  /**
+   * Check if string length is within a range (inclusive).
+   * Combines minLength and maxLength checks in a single validation.
+   */
+  lengthBetween: (value: unknown, args?: Record<string, unknown>) => {
+    if (typeof value !== "string") return false;
+    const min = args?.min;
+    const max = args?.max;
+    if (typeof min !== "number" || typeof max !== "number") return false;
+    return value.length >= min && value.length <= max;
+  },
+
+  /**
    * Check if value is a number
    */
   numeric: (value: unknown) => {
@@ -384,6 +408,22 @@ export const check = {
     type: "max",
     args: { max },
     message: message ?? `Must be at most ${max}`,
+  }),
+
+  between: (min: number, max: number, message?: string): ValidationCheck => ({
+    type: "between",
+    args: { min, max },
+    message: message ?? `Must be between ${min} and ${max}`,
+  }),
+
+  lengthBetween: (
+    min: number,
+    max: number,
+    message?: string,
+  ): ValidationCheck => ({
+    type: "lengthBetween",
+    args: { min, max },
+    message: message ?? `Must be between ${min} and ${max} characters`,
   }),
 
   url: (message = "Invalid URL"): ValidationCheck => ({


### PR DESCRIPTION
## Summary

Adds two new convenience validation functions for common range checking scenarios.

## New Functions

### `between`
Check if a numeric value is within a range (inclusive).

```json
{
  "type": "between",
  "args": { "min": 1, "max": 100 },
  "message": "Value must be between 1 and 100"
}
```

### `lengthBetween`
Check if a string length is within a range (inclusive).

```json
{
  "type": "lengthBetween",
  "args": { "min": 3, "max": 50 },
  "message": "Must be between 3 and 50 characters"
}
```

## Helper Functions

Also adds corresponding check helpers:

```typescript
check.between(1, 100, 'Out of range');
check.lengthBetween(3, 50, 'Invalid length');
```

## Motivation

Currently, checking both upper and lower bounds requires two separate checks:

```json
{
  "checks": [
    { "type": "min", "args": { "min": 1 }, "message": "Too low" },
    { "type": "max", "args": { "max": 100 }, "message": "Too high" }
  ]
}
```

With `between`, this becomes a single check with a single error message:

```json
{
  "checks": [
    { "type": "between", "args": { "min": 1, "max": 100 }, "message": "Must be 1-100" }
  ]
}
```

## Checklist

- [x] Tests added for both functions
- [x] Tests added for check helpers
- [x] No breaking changes