### PR TITLE
chore: patch release

### DIFF
--- a/.changeset/v0-15-release.md
+++ b/.changeset/v0-15-release.md
@@ -1,5 +1,5 @@
 ---
-"@json-render/core": minor
+"@json-render/core": patch
 ---
 
 Add yaml format support to `buildUserPrompt`


### PR DESCRIPTION
## Summary

- Adds a changeset for a patch release (0.14.1)
- Covers the new `format` and `serializer` options added to `buildUserPrompt` in `@json-render/core`, enabling YAML as a wire format alongside JSON (#223)

## Changeset

- **Type**: patch
- **Package**: `@json-render/core` (all fixed-group packages will be bumped together)

## Test plan

- [ ] CI passes (`pnpm type-check`, `pnpm test`)
- [ ] `pnpm ci:version` correctly bumps all fixed-group packages to 0.14.1