### PR TITLE
fix: deduplicate remotion to fix useVideoConfig in production

### DIFF
--- a/examples/remotion/next.config.js
+++ b/examples/remotion/next.config.js
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@json-render/core", "@json-render/remotion"],
+  turbopack: {
+    resolveAlias: {
+      // Deduplicate remotion — pnpm creates separate copies when peer
+      // dependency versions (React) differ between workspace packages.
+      // Force all imports to resolve from the app's node_modules.
+      remotion: "./node_modules/remotion",
+    },
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Problem

The remotion example throws `useVideoConfig()` error in production:

<img width="928" height="491" alt="image" src="https://github.com/user-attachments/assets/574267e9-b82c-4bd3-aca0-7859c8e802d3" />

<details>
<summary>Error stack trace</summary>

```
installHook.js:1 Error: No video config found. Likely reasons:
-- You are probably calling useVideoConfig() from outside the component passed to <Player />.
   See https://www.remotion.dev/docs/player/examples for how to set up the Player correctly.
-- You have multiple versions of Remotion installed which causes the React context to get lost.
    at pF (c6759ef9b85c6794.js?dpl=dpl_5DC7Zmn7mitSQtLShJiGVrtvuJuk:137:5041)
    at c6759ef9b85c6794.js?dpl=dpl_5DC7Zmn7mitSQtLShJiGVrtvuJuk:137:8209
    at av (5a0f99124522ad13.js?dpl=dpl_5DC7Zmn7mitSQtLShJiGVrtvuJuk:1:63271)
    at oV (5a0f99124522ad13.js?dpl=dpl_5DC7Zmn7mitSQtLShJiGVrtvuJuk:1:81291)
    at io (5a0f99124522ad13.js?dpl=dpl_5DC7Zmn7mitSQtLShJiGVrtvuJuk:1:98212)
    at sc (5a0f99124522ad13.js?dpl=dpl_5DC7Zmn7mitSQtLShJiGVrtvuJuk:1:137997)
    at 5a0f99124522ad13.js?dpl=dpl_5DC7Zmn7mitSQtLShJiGVrtvuJuk:1:137842
    at ss (5a0f99124522ad13.js?dpl=dpl_5DC7Zmn7mitSQtLShJiGVrtvuJuk:1:137850)
    at u9 (5a0f99124522ad13.js?dpl=dpl_5DC7Zmn7mitSQtLShJiGVrtvuJuk:1:133775)
    at sV (5a0f99124522ad13.js?dpl=dpl_5DC7Zmn7mitSQtLShJiGVrtvuJuk:1:159370)
```

</details>

## Root Cause

pnpm creates **two separate copies** of `remotion@4.0.418` because peer dependency versions differ between workspace packages:

| Package | Resolved `remotion` peer context |
|---|---|
| `example-remotion` | `react@19.2.3`, `react-dom@19.2.3` |
| `@json-render/remotion` | `react@19.2.4`, `react-dom@19.2.4` |

Two `remotion` instances → two `React.createContext()` calls → `<Player />` sets context in one copy, `useVideoConfig()` reads from the other → "No video config found".

## Fix

Add `turbopack.resolveAlias` in `next.config.js` to force all `remotion` imports to resolve from the app's `node_modules`, ensuring a single instance.

## Test plan
- [x] `pnpm --filter example-remotion build` succeeds with Turbopack
- [x] Verify video generation works in production deployment
