### PR TITLE
fix(core): handle Zod 4 record, default, and literal types in formatZodType

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1283,8 +1283,12 @@ function formatZodType(schema: z.ZodType): string {
     case "boolean":
       return "boolean";
     case "ZodLiteral":
-    case "literal":
-      return JSON.stringify(def.value);
+    case "literal": {
+      // Zod 4 uses def.values (array), Zod 3 uses def.value
+      const litValues = def.values as unknown[] | undefined;
+      const litValue = litValues?.[0] ?? def.value;
+      return JSON.stringify(litValue);
+    }
     case "ZodEnum":
     case "enum": {
       // Zod 3 uses values array, Zod 4 uses entries object
@@ -1344,6 +1348,20 @@ function formatZodType(schema: z.ZodType): string {
       return options
         ? options.map((opt) => formatZodType(opt)).join(" | ")
         : "unknown";
+    }
+    case "ZodRecord":
+    case "record": {
+      const keyType = (def.keyType as z.ZodType) ?? undefined;
+      const valueType =
+        (def.valueType as z.ZodType) ?? (def.element as z.ZodType) ?? undefined;
+      const keyStr = keyType ? formatZodType(keyType) : "string";
+      const valueStr = valueType ? formatZodType(valueType) : "unknown";
+      return `Record<${keyStr}, ${valueStr}>`;
+    }
+    case "ZodDefault":
+    case "default": {
+      const inner = (def.innerType as z.ZodType) ?? (def.wrapped as z.ZodType);
+      return inner ? formatZodType(inner) : "unknown";
     }
     default:
       return "unknown";

--- a/packages/yaml/src/prompt.ts
+++ b/packages/yaml/src/prompt.ts
@@ -56,8 +56,12 @@ function formatZodType(schema: ZodLike): string {
     case "boolean":
       return "boolean";
     case "ZodLiteral":
-    case "literal":
-      return JSON.stringify(def.value);
+    case "literal": {
+      // Zod 4 uses def.values (array), Zod 3 uses def.value
+      const litValues = def.values as unknown[] | undefined;
+      const litValue = litValues?.[0] ?? def.value;
+      return JSON.stringify(litValue);
+    }
     case "ZodEnum":
     case "enum": {
       let values: string[];
@@ -114,6 +118,20 @@ function formatZodType(schema: ZodLike): string {
       return options
         ? options.map((opt) => formatZodType(opt)).join(" | ")
         : "unknown";
+    }
+    case "ZodRecord":
+    case "record": {
+      const keyType = (def.keyType as ZodLike) ?? undefined;
+      const valueType =
+        (def.valueType as ZodLike) ?? (def.element as ZodLike) ?? undefined;
+      const keyStr = keyType ? formatZodType(keyType) : "string";
+      const valueStr = valueType ? formatZodType(valueType) : "unknown";
+      return `Record<${keyStr}, ${valueStr}>`;
+    }
+    case "ZodDefault":
+    case "default": {
+      const inner = (def.innerType as ZodLike) ?? (def.wrapped as ZodLike);
+      return inner ? formatZodType(inner) : "unknown";
     }
     default:
       return "unknown";


### PR DESCRIPTION
## Summary
- Adds `ZodRecord`/`record` case to `formatZodType()` - returns `Record<keyType, valueType>` with recursive formatting
- Adds `ZodDefault`/`default` case - unwraps to inner type (e.g., `z.boolean().default(false)` returns `"boolean"`)
- Fixes `ZodLiteral`/`literal` to support Zod 4's `def.values` array alongside Zod 3's `def.value`
- Applies the same fixes to both `@json-render/core` and `@json-render/yaml` packages

Fixes #231

## Test plan
- [x] All 862 existing tests pass
- [x] Type checking passes (`pnpm check-types`)

This contribution was developed with AI assistance (Claude Code).