### PR TITLE
fix(remotion): include props in generatePrompt output

### DIFF
--- a/packages/remotion/src/schema.ts
+++ b/packages/remotion/src/schema.ts
@@ -1,4 +1,5 @@
 import { defineSchema, type PromptContext } from "@json-render/core";
+import type { z } from "zod";
 
 /**
  * Prompt template for Remotion timeline generation
@@ -6,7 +7,7 @@ import { defineSchema, type PromptContext } from "@json-render/core";
  * Uses JSONL patch format (same as React) but builds up a timeline spec structure.
  */
 function remotionPromptTemplate(context: PromptContext): string {
-  const { catalog, options } = context;
+  const { catalog, options, formatZodType } = context;
   const { system = "You are a video timeline generator.", customRules = [] } =
     options;
 
@@ -37,7 +38,7 @@ function remotionPromptTemplate(context: PromptContext): string {
   const catalogData = catalog as {
     components?: Record<
       string,
-      { description?: string; defaultDuration?: number }
+      { description?: string; defaultDuration?: number; props?: z.ZodType }
     >;
     transitions?: Record<string, { description?: string }>;
     effects?: Record<string, { description?: string }>;
@@ -52,8 +53,9 @@ function remotionPromptTemplate(context: PromptContext): string {
       const duration = def.defaultDuration
         ? ` [default: ${def.defaultDuration} frames]`
         : "";
+      const propsStr = def.props ? ` ${formatZodType(def.props)}` : "";
       lines.push(
-        `- ${name}: ${def.description || "No description"}${duration}`,
+        `- ${name}:${propsStr} ${def.description || "No description"}${duration}`,
       );
     }
     lines.push("");


### PR DESCRIPTION
The Remotion schema defines props on composition entries (see [schema.ts#L184](https://github.com/vercel-labs/json-render/blob/main/packages/remotion/src/schema.ts#L184)), but generatePrompt did not include those props in its output ([schema.ts#L55–56](https://github.com/vercel-labs/json-render/blob/main/packages/remotion/src/schema.ts#L55-L56)).

As a result, the model had no knowledge of the expected prop shape when generating JSON, causing runtime failures when those prop names didn't match the component's expected interface.

## Changes
- Import zod type for TypeScript support  
- Extract formatZodType from PromptContext
- Add props field to component type definition
- Include formatted props string in component description

## Before
```
AVAILABLE COMPONENTS (1):
- TitleCard: A title card component [default: 90 frames]
```

## After
```
AVAILABLE COMPONENTS (1):
- TitleCard: { title: string, subtitle?: string } A title card component [default: 90 frames]
```

Fixes #224