### PR TITLE
fix: resolve image demo /api/image 500 on Vercel

### DIFF
--- a/examples/image/next.config.ts
+++ b/examples/image/next.config.ts
@@ -2,6 +2,11 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   serverExternalPackages: ["@resvg/resvg-js", "satori"],
+  outputFileTracingIncludes: {
+    "/api/image": [
+      "./node_modules/geist/dist/fonts/geist-sans/Geist-Regular.ttf",
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

<img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/1b39d5b2-5180-4c04-805c-4628e1d177bc" />


The `/api/image` endpoint returns 500 on `image-demo.json-render.dev`.

### Root cause

The image API uses Satori + resvg to render JSON specs into PNG. Satori requires font data passed as an `ArrayBuffer`, which the route loads via `fs.readFile` from:

```
process.cwd() + /node_modules/geist/dist/fonts/geist-sans/Geist-Regular.ttf
```

In a pnpm monorepo, `node_modules/geist` is a **symlink** pointing to the real location inside `node_modules/.pnpm/geist@.../`. Next.js file tracing (nft) traces the real path in the `.pnpm` store, but when Vercel assembles the serverless function it copies only the real file — the symlink at `node_modules/geist/...` does not exist in the function filesystem. So `readFile` throws `ENOENT` and the unhandled error surfaces as a 500.

### Fix

Added `outputFileTracingIncludes` in `next.config.ts` to explicitly include the font file at the symlink path, ensuring it is present where the code expects it.

## Test plan

- [x] Local build + `next start` — `/api/image` returns 200 with valid PNG