### PR TITLE
fix(core): infer s.any() as any instead of unknown in validate return type

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -342,7 +342,8 @@ type InferSpecField<T, TCatalog> =
                 : T extends SchemaType<"propsOf", infer Path>
                   ? InferPropsOfType<Path, TCatalog>
                   : T extends SchemaType<"any">
-                    ? unknown
+                    ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      any
                     : unknown;
 
 type InferRefType<Path, TCatalog> = Path extends "catalog.components"


### PR DESCRIPTION
## Summary

`InferSpecField` mapped `SchemaType<"any">` to `unknown`, making `catalog.validate()` return types incompatible with `Spec`. Fields like `visible: s.any()` produced `visible: unknown` instead of `visible: any`, forcing `as unknown as Spec` casts.

## Changes

`packages/core/src/schema.ts`: Changed the `InferSpecField` conditional type to map `SchemaType<"any">` to `any` instead of `unknown`. This matches how Zod's `z.any()` infers and makes the validated spec directly assignable to `Spec`.

## Testing

All 892 existing tests pass. `pnpm type-check` passes.

Fixes #251
