### PR TITLE
fix(core): preserve runtime fields in validate() with passthrough

### DIFF
--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -499,11 +499,14 @@ function buildZodType(schemaType: SchemaType, catalogData: unknown): z.ZodType {
         }
         zodShape[key] = zodType;
       }
-      return z.object(zodShape);
+      return z.object(zodShape).passthrough();
     }
     case "record": {
       const inner = buildZodType(schemaType.inner as SchemaType, catalogData);
-      return z.record(z.string(), inner);
+      return z.record(
+        z.string(),
+        inner instanceof z.ZodObject ? inner.passthrough() : inner,
+      );
     }
     case "ref": {
       // Reference to catalog key - create enum of valid keys


### PR DESCRIPTION
## Summary

`catalog.validate()` silently strips `on`, `repeat`, `watch`, and `state` from element objects because Zod's default parse mode removes unknown keys.

## Changes

`packages/core/src/schema.ts`: Added `.passthrough()` to object schemas in `buildZodType()` so unknown keys survive validation. Also applied to record schemas when their values are objects. Known fields are still validated; unknown fields (runtime fields like `on`, `repeat`, `watch`, `state`) pass through unchanged.

## Testing

All 892 existing tests pass. `pnpm type-check` passes.

Fixes #222