### PR TITLE
Update official links to use json-render.dev domain

### DIFF
--- a/apps/web/lib/examples.ts
+++ b/apps/web/lib/examples.ts
@@ -53,7 +53,7 @@ export const examples: Example[] = [
     description: "AI chat app built with SvelteKit and the Svelte renderer.",
     tags: ["Svelte", "SvelteKit", "AI"],
     githubPath: "examples/svelte-chat",
-    demoUrl: "https://json-render-svelte-chat-demo.labs.vercel.dev",
+    demoUrl: "https://svelte-chat-demo.json-render.dev",
   },
   {
     slug: "vue",

--- a/apps/web/lib/examples.ts
+++ b/apps/web/lib/examples.ts
@@ -53,7 +53,7 @@ export const examples: Example[] = [
     description: "AI chat app built with SvelteKit and the Svelte renderer.",
     tags: ["Svelte", "SvelteKit", "AI"],
     githubPath: "examples/svelte-chat",
-    demoUrl: "https://svelte-chat-demo.json-render.dev",
+    demoUrl: "https://json-render-svelte-chat-demo.labs.vercel.dev",
   },
   {
     slug: "vue",

--- a/examples/dashboard/components/header.tsx
+++ b/examples/dashboard/components/header.tsx
@@ -47,7 +47,7 @@ export function Header() {
         </div>
         <nav className="flex items-center gap-4">
           <a
-            href="https://json-render.vercel.app"
+            href="https://json-render.dev"
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-muted-foreground hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary
- Updated dashboard example Docs link from `json-render.vercel.app` to `json-render.dev`

Fixes #264

## Test plan
- [x] `pnpm type-check` passes (53/53 packages)
- [x] Dashboard example renders correctly with updated Docs link