### PR TITLE
fix(release): use npm publish for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,34 @@ jobs:
         run: pnpm run build
 
       - name: Publish all public packages
-        run: pnpm -r publish --provenance --no-git-checks --access public --filter '@json-render/*'
+        run: |
+          LOCAL_VERSION="${{ needs.check-release.outputs.version }}"
+          FAILED=""
+
+          publish_pkg() {
+            local dir="$1" name="$2"
+            REGISTRY_VERSION=$(npm view "$name" version 2>/dev/null || echo "0.0.0")
+            if [ "$LOCAL_VERSION" = "$REGISTRY_VERSION" ]; then
+              echo "$name@$LOCAL_VERSION already published, skipping"
+              return 0
+            fi
+            echo "Publishing $name@$LOCAL_VERSION..."
+            TARBALL=$(cd "$dir" && pnpm pack --pack-destination /tmp | tail -1)
+            if ! npm publish "$TARBALL" --provenance --access public; then
+              FAILED="$FAILED $name"
+            fi
+          }
+
+          for dir in packages/*/; do
+            PKG_NAME=$(node -p "try { const p = require('./$dir/package.json'); p.private ? '' : p.name } catch { '' }")
+            [ -z "$PKG_NAME" ] && continue
+            publish_pkg "$dir" "$PKG_NAME"
+          done
+
+          if [ -n "$FAILED" ]; then
+            echo "Failed to publish:$FAILED"
+            exit 1
+          fi
 
   github-release:
     name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 # Changelog
 
-## 0.18.0
+## 0.19.0
 
 <!-- release:start -->
+### New Features
+
+- **Custom directives API** — `@json-render/core` now supports custom directives via `defineDirective`, letting you declare new JSON shapes (like `$format`, `$math`) that resolve to computed values at render time. Directives compose naturally — nest `$format` over `$math` over `$state` and they resolve inside-out. All four renderers (React, Vue, Svelte, Solid) have built-in directive resolution (#279)
+- **`@json-render/directives`** — New package shipping seven ready-made directives: `$format` (date, currency, number, percent via `Intl`), `$math` (add, subtract, multiply, divide, mod, min, max, round, floor, ceil, abs), `$concat`, `$count`, `$truncate`, `$pluralize`, and `$join`. Also exports `createI18nDirective` for `$t` translation keys with `{{param}}` interpolation, and `standardDirectives` for one-line registration (#279)
+
+### Improvements
+
+- **Example READMEs** — Added documentation to the chat, dashboard, game-engine, and no-ai examples (#277)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.18.0
+
 ### New Features
 
 - **Devtools** — Five new packages for inspecting json-render apps in the browser: `@json-render/devtools` (framework-agnostic core), plus `@json-render/devtools-react`, `@json-render/devtools-vue`, `@json-render/devtools-svelte`, and `@json-render/devtools-solid` adapters. Drop `<JsonRenderDevtools />` into your app to get a shadow-DOM-isolated panel with six tabs (Spec, State, Actions, Stream, Catalog, Pick), a DOM picker that maps clicked elements back to spec keys via `data-jr-key`, a capped event store, and server-side stream tap utilities. Floating toggle or `Cmd`/`Ctrl` + `Shift` + `J`, tree-shakes to `null` in production (#273)
@@ -21,7 +37,6 @@
 
 - @ctate
 - @mvanhorn
-<!-- release:end -->
 
 ## 0.17.0
 

--- a/apps/web/app/(main)/docs/changelog/page.mdx
+++ b/apps/web/app/(main)/docs/changelog/page.mdx
@@ -5,6 +5,35 @@ export const metadata = pageMetadata("docs/changelog")
 
 Notable changes and updates to json-render.
 
+## v0.19.0
+
+May 6, 2026
+
+### New: Custom Directives API
+
+`@json-render/core` now supports custom directives via `defineDirective`, letting you declare new JSON shapes (like `$format`, `$math`) that resolve to computed values at render time. Directives compose naturally -- nest `$format` over `$math` over `$state` and they resolve inside-out. All four renderers (React, Vue, Svelte, Solid) have built-in directive resolution.
+
+### New: `@json-render/directives`
+
+New package shipping seven ready-made directives: `$format` (date, currency, number, percent via `Intl`), `$math` (arithmetic and rounding), `$concat`, `$count`, `$truncate`, `$pluralize`, and `$join`. Also exports `createI18nDirective` for `$t` translation keys with interpolation, and `standardDirectives` for one-line registration.
+
+```bash
+npm install @json-render/directives
+```
+
+```tsx
+import { standardDirectives } from "@json-render/directives";
+
+const catalog = createCatalog({
+  directives: standardDirectives,
+  // ...
+});
+```
+
+See the [Directives guide](/docs/directives) and the [API reference](/docs/api/directives) for details.
+
+---
+
 ## v0.18.0
 
 April 17, 2026

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/codegen",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Utilities for generating code from json-render UI trees",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/core",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "JSON becomes real things. Define your catalog, register your components, let AI generate.",
   "keywords": [

--- a/packages/devtools-react/package.json
+++ b/packages/devtools-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-react",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "React adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools-solid/package.json
+++ b/packages/devtools-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-solid",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "SolidJS adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools-svelte/package.json
+++ b/packages/devtools-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-svelte",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Svelte adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools-vue/package.json
+++ b/packages/devtools-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-vue",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Vue adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Framework-agnostic devtools core for json-render: event store, panel UI, picker, stream taps.",
   "keywords": [

--- a/packages/directives/package.json
+++ b/packages/directives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/directives",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Pre-built directives for @json-render/core — $format, $math, $concat, $count, $truncate, $pluralize, $join, and $t (i18n).",
   "keywords": [

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/image",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Image renderer for @json-render/core. JSON becomes SVG and PNG images via Satori.",
   "keywords": [

--- a/packages/ink/package.json
+++ b/packages/ink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/ink",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Ink terminal renderer for @json-render/core. JSON becomes terminal UIs.",
   "keywords": [

--- a/packages/jotai/package.json
+++ b/packages/jotai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/jotai",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Jotai adapter for json-render StateStore",
   "keywords": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/mcp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "MCP Apps integration for @json-render/core. Serve json-render UIs as interactive MCP Apps in Claude, ChatGPT, Cursor, and VS Code.",
   "keywords": [

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/next",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Next.js renderer for @json-render/core. JSON becomes full Next.js applications with routes, layouts, metadata, and SSR.",
   "keywords": [

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-email",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "React Email renderer for @json-render/core. JSON becomes HTML emails.",
   "keywords": [

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-native",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "React Native renderer for @json-render/core. JSON becomes React Native components.",
   "keywords": [

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-pdf",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "React PDF renderer for @json-render/core. JSON becomes PDF documents.",
   "keywords": [

--- a/packages/react-three-fiber/package.json
+++ b/packages/react-three-fiber/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-three-fiber",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "React Three Fiber renderer for @json-render/core. JSON becomes 3D scenes.",
   "keywords": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "React renderer for @json-render/core. JSON becomes React components.",
   "keywords": [

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/redux",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Redux adapter for json-render StateStore",
   "keywords": [

--- a/packages/remotion/package.json
+++ b/packages/remotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/remotion",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Remotion renderer for @json-render/core. JSON becomes video compositions.",
   "keywords": [

--- a/packages/shadcn-svelte/package.json
+++ b/packages/shadcn-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/shadcn-svelte",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "shadcn-svelte component library for @json-render/svelte. JSON becomes beautiful Tailwind-styled Svelte components.",
   "keywords": [

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/shadcn",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "shadcn/ui component library for @json-render/core. JSON becomes beautiful Tailwind-styled React components.",
   "keywords": [

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/solid",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "SolidJS renderer for @json-render/core. JSON becomes Solid components.",
   "keywords": [

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/svelte",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Svelte 5 renderer for @json-render/core. JSON becomes Svelte components.",
   "keywords": [

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/vue",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Vue renderer for @json-render/core. JSON becomes Vue components.",
   "keywords": [

--- a/packages/xstate/package.json
+++ b/packages/xstate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/xstate",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "XState Store adapter for json-render StateStore",
   "keywords": [

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/yaml",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "YAML wire format for @json-render/core. Progressive rendering and surgical edits via streaming YAML.",
   "keywords": [

--- a/packages/zustand/package.json
+++ b/packages/zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/zustand",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "Apache-2.0",
   "description": "Zustand adapter for json-render StateStore",
   "keywords": [


### PR DESCRIPTION
## Summary

- Fix E404 during OIDC trusted publishing by switching from `pnpm -r publish` to `pnpm pack` + `npm publish` per package
- `pnpm publish` does not pass through OIDC credentials, but `npm publish --provenance` handles the token exchange natively
- Adds per-package version check so re-runs skip already-published packages