### PR TITLE
hardening href validation

### DIFF
--- a/packages/shadcn-svelte/src/catalog.ts
+++ b/packages/shadcn-svelte/src/catalog.ts
@@ -401,7 +401,10 @@ export const shadcnComponentDefinitions = {
   Link: {
     props: z.object({
       label: z.string(),
-      href: z.string(),
+      href: z.union([
+        z.url({ protocol: /^(https?|mailto)$/ }),
+        z.string().regex(/^\/(?!\/)/),
+      ]),
     }),
     events: ["press"],
     description: "Anchor link. Bind on.press for click handler.",

--- a/packages/shadcn/src/catalog.ts
+++ b/packages/shadcn/src/catalog.ts
@@ -404,7 +404,10 @@ export const shadcnComponentDefinitions = {
   Link: {
     props: z.object({
       label: z.string(),
-      href: z.string(),
+      href: z.union([
+        z.url({ protocol: /^(https?|mailto)$/ }),
+        z.string().regex(/^\/(?!\/)/),
+      ]),
     }),
     events: ["press"],
     description: "Anchor link. Bind on.press for click handler.",


### PR DESCRIPTION
## Summary

Tightens validation for `href` values in the Shadcn link schema.

After this links will only support:

- `http`
- `https`
- `mailto`
- relative paths like `/docs`