### PR TITLE
fix(core,shadcn-svelte): make zod a peer-only dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,13 +49,11 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "zod": "^4.3.6"
-  },
   "devDependencies": {
     "@internal/typescript-config": "workspace:*",
     "tsup": "^8.0.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "zod": "^4.3.6"
   },
   "peerDependencies": {
     "zod": "^4.0.0"

--- a/packages/shadcn-svelte/package.json
+++ b/packages/shadcn-svelte/package.json
@@ -65,8 +65,7 @@
     "embla-carousel-svelte": "^8.6.0",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",
-    "vaul-svelte": "1.0.0-next.7",
-    "zod": "^4.3.6"
+    "vaul-svelte": "1.0.0-next.7"
   },
   "devDependencies": {
     "@fontsource-variable/inter": "^5.2.8",
@@ -77,7 +76,8 @@
     "svelte": "^5.54.1",
     "svelte-check": "^4.4.5",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "zod": "^4.3.6"
   },
   "peerDependencies": {
     "svelte": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,10 +73,10 @@ importers:
     dependencies:
       '@ai-sdk/gateway':
         specifier: ^3.0.13
-        version: 3.0.57(zod@4.3.6)
+        version: 3.0.57(zod@4.4.3)
       '@ai-sdk/react':
         specifier: 3.0.79
-        version: 3.0.79(react@19.2.3)(zod@4.3.6)
+        version: 3.0.79(react@19.2.3)(zod@4.4.3)
       '@json-render/codegen':
         specifier: workspace:*
         version: link:../../packages/codegen
@@ -133,10 +133,10 @@ importers:
         version: 0.1.1(react@19.2.3)
       ai:
         specifier: ^6.0.33
-        version: 6.0.103(zod@4.3.6)
+        version: 6.0.103(zod@4.4.3)
       bash-tool:
         specifier: 1.3.14
-        version: 1.3.14(@vercel/sandbox@2.2.0)(ai@6.0.103(zod@4.3.6))
+        version: 1.3.14(@vercel/sandbox@2.2.0)(ai@6.0.103(zod@4.4.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -199,7 +199,7 @@ importers:
         version: 2.8.2
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@internal/eslint-config':
         specifier: workspace:*
@@ -354,7 +354,7 @@ importers:
     dependencies:
       '@ai-sdk/gateway':
         specifier: ^3.0.13
-        version: 3.0.57(zod@4.3.6)
+        version: 3.0.57(zod@4.4.3)
       '@dnd-kit/core':
         specifier: 6.3.1
         version: 6.3.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -381,7 +381,7 @@ importers:
         version: 1.37.0
       ai:
         specifier: ^6.0.33
-        version: 6.0.103(zod@4.3.6)
+        version: 6.0.103(zod@4.4.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -429,7 +429,7 @@ importers:
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@internal/eslint-config':
         specifier: workspace:*
@@ -886,10 +886,10 @@ importers:
         version: link:../../packages/shadcn
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.2.0
-        version: 1.2.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 1.2.0(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
-        version: 1.27.1(zod@4.3.6)
+        version: 1.27.1(zod@4.4.3)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -898,7 +898,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.1
@@ -1160,7 +1160,7 @@ importers:
     dependencies:
       '@ai-sdk/gateway':
         specifier: ^3.0.39
-        version: 3.0.57(zod@4.3.6)
+        version: 3.0.57(zod@4.4.3)
       '@expo/vector-icons':
         specifier: ^15.0.3
         version: 15.0.3(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1172,7 +1172,7 @@ importers:
         version: link:../../packages/react-native
       ai:
         specifier: ^6.0.77
-        version: 6.0.103(zod@4.3.6)
+        version: 6.0.103(zod@4.4.3)
       expo:
         specifier: ~54.0.33
         version: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1205,7 +1205,7 @@ importers:
         version: 4.11.1(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^22.10.0
@@ -1410,7 +1410,7 @@ importers:
     dependencies:
       '@ai-sdk/gateway':
         specifier: ^3.0.13
-        version: 3.0.57(zod@4.3.6)
+        version: 3.0.57(zod@4.4.3)
       '@json-render/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -1434,7 +1434,7 @@ importers:
         version: 1.37.0
       ai:
         specifier: ^6.0.70
-        version: 6.0.103(zod@4.3.6)
+        version: 6.0.103(zod@4.4.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1464,7 +1464,7 @@ importers:
         version: 3.5.0
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@internal/eslint-config':
         specifier: workspace:*
@@ -1504,7 +1504,7 @@ importers:
         version: 1.9.11
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       typescript:
         specifier: ^5.9.3
@@ -1520,10 +1520,10 @@ importers:
     dependencies:
       '@ai-sdk/gateway':
         specifier: ^3.0.50
-        version: 3.0.57(zod@4.3.6)
+        version: 3.0.57(zod@4.4.3)
       ai:
         specifier: ^6.0.91
-        version: 6.0.103(zod@4.3.6)
+        version: 6.0.103(zod@4.4.3)
       next:
         specifier: ^16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1560,7 +1560,7 @@ importers:
         version: 13.11.0
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@internal/eslint-config':
         specifier: workspace:*
@@ -1588,7 +1588,7 @@ importers:
         version: 13.11.0
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@internal/eslint-config':
         specifier: workspace:*
@@ -1810,10 +1810,6 @@ importers:
         version: 5.9.3
 
   packages/core:
-    dependencies:
-      zod:
-        specifier: ^4.3.6
-        version: 4.3.6
     devDependencies:
       '@internal/typescript-config':
         specifier: workspace:*
@@ -1824,6 +1820,9 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
 
   packages/devtools:
     dependencies:
@@ -1973,7 +1972,7 @@ importers:
         version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.19.6)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@22.19.6)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
 
   packages/eslint-config:
     devDependencies:
@@ -2040,7 +2039,7 @@ importers:
         version: 5.9.3
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
 
   packages/ink:
     dependencies:
@@ -2074,7 +2073,7 @@ importers:
         version: 5.9.3
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
 
   packages/jotai:
     dependencies:
@@ -2102,10 +2101,10 @@ importers:
         version: link:../core
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.2.0
-        version: 1.2.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 1.2.0(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
-        version: 1.27.1(zod@4.3.6)
+        version: 1.27.1(zod@4.4.3)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -2180,7 +2179,7 @@ importers:
         version: 5.9.3
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
 
   packages/react-email:
     dependencies:
@@ -2211,7 +2210,7 @@ importers:
         version: 5.9.3
       zod:
         specifier: ^4.0.0
-        version: 4.3.6
+        version: 4.4.3
 
   packages/react-native:
     dependencies:
@@ -2242,7 +2241,7 @@ importers:
         version: 5.9.3
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
 
   packages/react-pdf:
     dependencies:
@@ -2273,7 +2272,7 @@ importers:
         version: 5.9.3
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
 
   packages/react-state:
     dependencies:
@@ -2344,7 +2343,7 @@ importers:
         version: 5.9.3
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
 
   packages/redux:
     dependencies:
@@ -2394,7 +2393,7 @@ importers:
         version: 5.9.3
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
 
   packages/shadcn:
     dependencies:
@@ -2449,7 +2448,7 @@ importers:
         version: 5.9.3
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
 
   packages/shadcn-svelte:
     dependencies:
@@ -2483,9 +2482,6 @@ importers:
       vaul-svelte:
         specifier: 1.0.0-next.7
         version: 1.0.0-next.7(svelte@5.54.1)
-      zod:
-        specifier: ^4.3.6
-        version: 4.3.6
     devDependencies:
       '@fontsource-variable/inter':
         specifier: ^5.2.8
@@ -2514,6 +2510,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.3
 
   packages/solid:
     dependencies:
@@ -2538,7 +2537,7 @@ importers:
         version: 5.9.3
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
 
   packages/svelte:
     dependencies:
@@ -2547,7 +2546,7 @@ importers:
         version: link:../core
       zod:
         specifier: ^4.0.0
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@internal/typescript-config':
         specifier: workspace:*
@@ -2608,7 +2607,7 @@ importers:
         version: link:../core
       zod:
         specifier: ^4.0.0
-        version: 4.3.6
+        version: 4.4.3
     devDependencies:
       '@internal/typescript-config':
         specifier: workspace:*
@@ -2671,7 +2670,7 @@ importers:
         version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.19.6)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@22.19.6)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
 
   packages/zustand:
     dependencies:
@@ -2696,7 +2695,7 @@ importers:
     devDependencies:
       '@ai-sdk/gateway':
         specifier: ^3.0.53
-        version: 3.0.57(zod@4.3.6)
+        version: 3.0.57(zod@4.4.3)
       '@json-render/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -2723,7 +2722,7 @@ importers:
         version: 19.2.14
       ai:
         specifier: ^6.0.97
-        version: 6.0.103(zod@4.3.6)
+        version: 6.0.103(zod@4.4.3)
       ink:
         specifier: ^6.8.0
         version: 6.8.0(@types/react@19.2.14)(react-devtools-core@6.1.5)(react@19.2.4)
@@ -2741,7 +2740,7 @@ importers:
         version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.19.6)(jiti@2.7.0)(jsdom@27.4.0)(lightningcss@1.32.0)(msw@2.12.10(@types/node@22.19.6)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
       zod:
         specifier: ^4.3.6
-        version: 4.3.6
+        version: 4.4.3
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -14985,6 +14984,9 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
     engines: {node: '>=12.7.0'}
@@ -15054,12 +15056,12 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.3.6
 
-  '@ai-sdk/gateway@3.0.39(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.39(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.14(zod@4.4.3)
       '@vercel/oidc': 3.1.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@ai-sdk/gateway@3.0.42(zod@4.3.6)':
     dependencies:
@@ -15088,6 +15090,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.15(zod@4.3.6)
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
+
+  '@ai-sdk/gateway@3.0.57(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@4.4.3)
+      '@vercel/oidc': 3.1.0
+      zod: 4.4.3
 
   '@ai-sdk/gateway@3.0.66(zod@4.3.6)':
     dependencies:
@@ -15178,12 +15187,26 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@4.0.14(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@4.0.15(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.15(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.19(zod@4.3.6)':
     dependencies:
@@ -15233,10 +15256,10 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/react@3.0.79(react@19.2.3)(zod@4.3.6)':
+  '@ai-sdk/react@3.0.79(react@19.2.3)(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
-      ai: 6.0.77(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.14(zod@4.4.3)
+      ai: 6.0.77(zod@4.4.3)
       react: 19.2.3
       swr: 2.4.0(react@19.2.3)
       throttleit: 2.1.0
@@ -16836,7 +16859,6 @@ snapshots:
       - graphql
       - supports-color
       - utf-8-validate
-    optional: true
 
   '@expo/code-signing-certificates@0.0.6':
     dependencies:
@@ -16901,7 +16923,6 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
       react-native: 0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4)
-    optional: true
 
   '@expo/env@2.0.8':
     dependencies:
@@ -16971,7 +16992,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -17052,7 +17073,7 @@ snapshots:
       '@expo/json-file': 10.0.8
       '@react-native/normalize-colors': 0.81.5
       debug: 4.4.3
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4))(react@19.2.4)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -17080,7 +17101,6 @@ snapshots:
       expo-font: 14.0.11(expo@54.0.33)(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-native: 0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4)
-    optional: true
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -17637,7 +17657,7 @@ snapshots:
       '@mdx-js/mdx': 3.1.1
       source-map: 0.7.6
     optionalDependencies:
-      webpack: 5.96.1(esbuild@0.25.0)
+      webpack: 5.96.1
     transitivePeerDependencies:
       - supports-color
 
@@ -17686,16 +17706,16 @@ snapshots:
   '@mistralai/mistralai@2.2.1':
     dependencies:
       ws: 8.21.0
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@modelcontextprotocol/ext-apps@1.2.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
+  '@modelcontextprotocol/ext-apps@1.2.0(@modelcontextprotocol/sdk@1.27.1(zod@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
-      zod: 4.3.6
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.4.3)
+      zod: 4.4.3
     optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -17741,6 +17761,29 @@ snapshots:
       raw-body: 3.0.2
       zod: 4.3.6
       zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.0)
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.0
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -21884,7 +21927,7 @@ snapshots:
       tar-stream: 3.1.7
       undici: 7.27.2
       xdg-app-paths: 5.1.0
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
@@ -22236,6 +22279,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
+  ai@6.0.103(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.57(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
+
   ai@6.0.116(zod@4.3.6):
     dependencies:
       '@ai-sdk/gateway': 3.0.66(zod@4.3.6)
@@ -22252,13 +22303,13 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
-  ai@6.0.77(zod@4.3.6):
+  ai@6.0.77(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.39(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.39(zod@4.4.3)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.14(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   ai@6.0.82(zod@4.3.6):
     dependencies:
@@ -22623,7 +22674,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.28.6
-      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -22663,9 +22714,9 @@ snapshots:
 
   baseline-browser-mapping@2.9.14: {}
 
-  bash-tool@1.3.14(@vercel/sandbox@2.2.0)(ai@6.0.103(zod@4.3.6)):
+  bash-tool@1.3.14(@vercel/sandbox@2.2.0)(ai@6.0.103(zod@4.4.3)):
     dependencies:
-      ai: 6.0.103(zod@4.3.6)
+      ai: 6.0.103(zod@4.4.3)
       fast-glob: 3.3.3
       gray-matter: 4.0.3
       zod: 3.25.76
@@ -24259,7 +24310,6 @@ snapshots:
       react-native: 0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   expo-clipboard@8.0.8(expo@54.0.33)(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -24284,7 +24334,6 @@ snapshots:
       react-native: 0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   expo-file-system@19.0.21(expo@54.0.33)(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
@@ -24295,7 +24344,6 @@ snapshots:
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4))(react@19.2.4)
       react-native: 0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4)
-    optional: true
 
   expo-font@14.0.11(expo@54.0.33)(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -24310,7 +24358,6 @@ snapshots:
       fontfaceobserver: 2.3.0
       react: 19.2.4
       react-native: 0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4)
-    optional: true
 
   expo-keep-awake@15.0.8(expo@54.0.33)(react@19.1.0):
     dependencies:
@@ -24321,7 +24368,6 @@ snapshots:
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.12.0)(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4))(react@19.2.4)
       react: 19.2.4
-    optional: true
 
   expo-linking@8.0.11(expo@54.0.33)(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -24363,7 +24409,6 @@ snapshots:
       invariant: 2.2.4
       react: 19.2.4
       react-native: 0.83.1(@babel/core@7.29.0)(@types/react@19.2.3)(react@19.2.4)
-    optional: true
 
   expo-router@6.0.23(@expo/metro-runtime@6.1.2)(@types/react-dom@19.2.3(@types/react@19.1.17))(@types/react@19.1.17)(expo-constants@18.0.13)(expo-linking@8.0.11)(expo@54.0.33)(react-dom@19.2.4(react@19.1.0))(react-native-safe-area-context@5.4.0(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.11.1(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -24524,7 +24569,6 @@ snapshots:
       - graphql
       - supports-color
       - utf-8-validate
-    optional: true
 
   exponential-backoff@3.1.3: {}
 
@@ -29933,6 +29977,16 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.0
 
+  terser-webpack-plugin@5.3.16(webpack@5.96.1):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.46.0
+      webpack: 5.96.1
+    optional: true
+
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -30856,6 +30910,37 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
+  webpack@5.96.1:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.19.0
+      es-module-lexer: 1.7.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(webpack@5.96.1)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    optional: true
+
   webpack@5.96.1(esbuild@0.25.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
@@ -31124,12 +31209,19 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+    optional: true
+
+  zod-to-json-schema@3.25.1(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@3.22.3: {}
 
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}
 
   zustand@4.5.7(@types/react@19.2.3)(immer@11.1.4)(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary

Fixes #297.

`@json-render/core` and `@json-render/shadcn-svelte` listed `zod` in **both** `dependencies` (`^4.3.6`) and `peerDependencies` (`^4.0.0`). Package managers can resolve the `dependencies` entry to a second zod copy distinct from the consumer's (e.g. a lockfile that pinned 4.3.x while the app uses 4.4.x). zod v4 intentionally embeds a version literal in its types (`_zod.version.minor`), so two copies are structurally incompatible and consumers hit:

```
The types of 'props._zod.version.minor' are incompatible between these types.
  Type '4' is not assignable to type '3'.
```

plus `type instantiation is excessively deep` errors and tsc memory blowups from the cross-copy structural comparison.

## Fix

Move `zod` to `devDependencies` in both packages, keeping the `^4.0.0` peer range. The consumer's zod is then always the only copy.

## Verification

- Reproduced #297 exactly against published `@json-render/solid@0.19.0` with `zod@4.4.3` and a nested 4.3.6 copy under core (same error text as the issue).
- Rebuilt core + solid from this branch, packed with `pnpm pack`, installed in fresh **npm** and **pnpm** consumers with `zod@4.4.3`: one zod resolved (`pnpm why zod` → "Found 1 version"), the issue's repro (`schema.createCatalog` + registry) typechecks cleanly.
- Workspace: all packages build and all 1021 unit tests pass with zod resolved to **4.3.6** and (via a temporary override) **4.4.3**.