### PR TITLE
fix(image,react-pdf): resolve Buffer/stream type errors breaking build

### DIFF
--- a/packages/image/src/render.tsx
+++ b/packages/image/src/render.tsx
@@ -206,5 +206,6 @@ export async function renderToPng(
 
   const resvg = new Resvg(svg);
   const pngData = resvg.render();
-  return pngData.asPng();
+  const png = pngData.asPng();
+  return new Uint8Array(png.buffer, png.byteOffset, png.byteLength);
 }

--- a/packages/react-pdf/src/render.tsx
+++ b/packages/react-pdf/src/render.tsx
@@ -153,7 +153,8 @@ export async function renderToBuffer(
   options?: RenderOptions,
 ): Promise<Uint8Array> {
   const document = buildDocument(spec, options);
-  return pdfRenderToBuffer(document as any);
+  const buffer = await pdfRenderToBuffer(document as any);
+  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
 }
 
 /**
@@ -162,7 +163,7 @@ export async function renderToBuffer(
 export async function renderToStream(
   spec: Spec,
   options?: RenderOptions,
-): Promise<ReadableStream> {
+): Promise<NodeJS.ReadableStream> {
   const document = buildDocument(spec, options);
   return pdfRenderToStream(document as any);
 }


### PR DESCRIPTION
## Summary

`@json-render/image` and `@json-render/react-pdf` currently fail `build` (dts) and `check-types` on main:

```
image/src/render.tsx(209,3): error TS2322: Type 'Buffer' is not assignable to type 'Uint8Array<ArrayBufferLike>'.
react-pdf/src/render.tsx(156,3): error TS2322: Type 'Buffer' is not assignable to type 'Uint8Array<ArrayBufferLike>'.
react-pdf/src/render.tsx(167,3): error TS2740: Type 'ReadableStream' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, ...
```

Since the release workflow's publish job runs `pnpm run build`, **this blocks the next release**.

## Fix

- `renderToPng` / `renderToBuffer`: `@resvg/resvg-js`'s `asPng()` and `@react-pdf/renderer`'s `renderToBuffer()` return Node `Buffer`; wrap in zero-copy `Uint8Array` views to satisfy the declared platform-neutral return types.
- `renderToStream`: was declared `Promise<ReadableStream>` (web), but `@react-pdf/renderer`'s `renderToStream()` actually resolves to a `NodeJS.ReadableStream`. Declare what it really returns — treating the old type as a web stream would fail at runtime.

## Verification

All 24 package builds pass and 1021/1021 unit tests pass on this branch; both failures reproduce on unmodified main.