### PR TITLE
prepare v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
 # Changelog
 
-## 0.19.0
+## 0.19.1
 
 <!-- release:start -->
+### Bug Fixes
+
+- **zod 4.4+ compatibility** — `@json-render/core` and `@json-render/shadcn-svelte` listed zod in both `dependencies` and `peerDependencies`, which could give the library its own zod copy distinct from your app's. zod 4 embeds a version literal in its types, so the duplicate copies surfaced as `Type '4' is not assignable to type '3'` errors on `_zod.version.minor` and blocked upgrading to zod 4.4+. zod is now a peer-only dependency, so your app's zod is always the single copy (#297, #303)
+- **`visible` validation on zod 4.4+** — `catalog.validate()` accepted specs that omit an element's `visible` field on zod 4.3 but rejected them on zod 4.4+, where `z.any()` object keys became non-optional. `visible` is now explicitly optional so all zod 4.x versions agree (#287, #299)
+- **Dangling children autofix** — `autoFixSpec` now prunes `children` references to elements that don't exist in the spec, the dominant remaining first-attempt validation failure for AI-generated specs. The renderer already skipped missing children at runtime, so pruning renders identically while letting the spec validate; each removal is reported in `fixes` (#300)
+- **PDF and image render types** — Fixed `Buffer`/`Uint8Array` type errors in `@json-render/image`'s `renderToPng` and `@json-render/react-pdf`'s `renderToBuffer` under current `@types/node`, and corrected `renderToStream`'s declared return type to `NodeJS.ReadableStream`, which is what `@react-pdf/renderer` actually returns (#304)
+
+### Improvements
+
+- **Prompt rules for children** — The default prompt now states explicitly that every element must include a `children` array (`[]` for leaves), which models otherwise omitted on roughly a third of first attempts (#299)
+- **Harness agent chat example** — New `examples/harness-chat` demo running a coding agent (Claude Code, Codex, or Pi) in a Vercel Sandbox via the AI SDK `HarnessAgent` API, rendering its work reports as json-render generative UI instead of markdown (#302)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.19.0
+
 ### New Features
 
 - **Custom directives API** — `@json-render/core` now supports custom directives via `defineDirective`, letting you declare new JSON shapes (like `$format`, `$math`) that resolve to computed values at render time. Directives compose naturally — nest `$format` over `$math` over `$state` and they resolve inside-out. All four renderers (React, Vue, Svelte, Solid) have built-in directive resolution (#279)
@@ -15,7 +34,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.18.0
 

--- a/apps/web/app/(main)/docs/changelog/page.mdx
+++ b/apps/web/app/(main)/docs/changelog/page.mdx
@@ -5,6 +5,30 @@ export const metadata = pageMetadata("docs/changelog")
 
 Notable changes and updates to json-render.
 
+## v0.19.1
+
+July 1, 2026
+
+### Fixed: zod 4.4+ compatibility
+
+`@json-render/core` and `@json-render/shadcn-svelte` listed zod in both `dependencies` and `peerDependencies`, which could give the library its own zod copy distinct from your app's. zod 4 embeds a version literal in its types, so the duplicate copies surfaced as `Type '4' is not assignable to type '3'` errors on `_zod.version.minor` and blocked upgrading to zod 4.4+. zod is now a peer-only dependency, so your app's zod is always the single copy.
+
+Relatedly, `catalog.validate()` accepted specs that omit an element's `visible` field on zod 4.3 but rejected them on zod 4.4+, where `z.any()` object keys became non-optional. `visible` is now explicitly optional so all zod 4.x versions agree.
+
+### Fixed: dangling children autofix
+
+`autoFixSpec` now prunes `children` references to elements that don't exist in the spec -- the dominant remaining first-attempt validation failure for AI-generated specs. The renderer already skipped missing children at runtime, so pruning renders identically while letting the spec validate; each removal is reported in `fixes`.
+
+### Fixed: PDF and image render types
+
+Fixed `Buffer`/`Uint8Array` type errors in `@json-render/image`'s `renderToPng` and `@json-render/react-pdf`'s `renderToBuffer` under current `@types/node`, and corrected `renderToStream`'s declared return type to `NodeJS.ReadableStream`, which is what `@react-pdf/renderer` actually returns.
+
+### New: harness agent chat example
+
+New `examples/harness-chat` demo running a coding agent (Claude Code, Codex, or Pi) in a Vercel Sandbox via the AI SDK `HarnessAgent` API, rendering its work reports as json-render generative UI instead of markdown.
+
+---
+
 ## v0.19.0
 
 May 6, 2026

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/codegen",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Utilities for generating code from json-render UI trees",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/core",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "JSON becomes real things. Define your catalog, register your components, let AI generate.",
   "keywords": [

--- a/packages/devtools-react/package.json
+++ b/packages/devtools-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-react",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "React adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools-solid/package.json
+++ b/packages/devtools-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-solid",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "SolidJS adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools-svelte/package.json
+++ b/packages/devtools-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-svelte",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Svelte adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools-vue/package.json
+++ b/packages/devtools-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-vue",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Vue adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Framework-agnostic devtools core for json-render: event store, panel UI, picker, stream taps.",
   "keywords": [

--- a/packages/directives/package.json
+++ b/packages/directives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/directives",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Pre-built directives for @json-render/core — $format, $math, $concat, $count, $truncate, $pluralize, $join, and $t (i18n).",
   "keywords": [

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/image",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Image renderer for @json-render/core. JSON becomes SVG and PNG images via Satori.",
   "keywords": [

--- a/packages/ink/package.json
+++ b/packages/ink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/ink",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Ink terminal renderer for @json-render/core. JSON becomes terminal UIs.",
   "keywords": [

--- a/packages/jotai/package.json
+++ b/packages/jotai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/jotai",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Jotai adapter for json-render StateStore",
   "keywords": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/mcp",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "MCP Apps integration for @json-render/core. Serve json-render UIs as interactive MCP Apps in Claude, ChatGPT, Cursor, and VS Code.",
   "keywords": [

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/next",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Next.js renderer for @json-render/core. JSON becomes full Next.js applications with routes, layouts, metadata, and SSR.",
   "keywords": [

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-email",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "React Email renderer for @json-render/core. JSON becomes HTML emails.",
   "keywords": [

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-native",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "React Native renderer for @json-render/core. JSON becomes React Native components.",
   "keywords": [

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-pdf",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "React PDF renderer for @json-render/core. JSON becomes PDF documents.",
   "keywords": [

--- a/packages/react-three-fiber/package.json
+++ b/packages/react-three-fiber/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-three-fiber",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "React Three Fiber renderer for @json-render/core. JSON becomes 3D scenes.",
   "keywords": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "React renderer for @json-render/core. JSON becomes React components.",
   "keywords": [

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/redux",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Redux adapter for json-render StateStore",
   "keywords": [

--- a/packages/remotion/package.json
+++ b/packages/remotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/remotion",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Remotion renderer for @json-render/core. JSON becomes video compositions.",
   "keywords": [

--- a/packages/shadcn-svelte/package.json
+++ b/packages/shadcn-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/shadcn-svelte",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "shadcn-svelte component library for @json-render/svelte. JSON becomes beautiful Tailwind-styled Svelte components.",
   "keywords": [

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/shadcn",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "shadcn/ui component library for @json-render/core. JSON becomes beautiful Tailwind-styled React components.",
   "keywords": [

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/solid",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "SolidJS renderer for @json-render/core. JSON becomes Solid components.",
   "keywords": [

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/svelte",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Svelte 5 renderer for @json-render/core. JSON becomes Svelte components.",
   "keywords": [

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/vue",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Vue renderer for @json-render/core. JSON becomes Vue components.",
   "keywords": [

--- a/packages/xstate/package.json
+++ b/packages/xstate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/xstate",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "XState Store adapter for json-render StateStore",
   "keywords": [

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/yaml",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "YAML wire format for @json-render/core. Progressive rendering and surgical edits via streaming YAML.",
   "keywords": [

--- a/packages/zustand/package.json
+++ b/packages/zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/zustand",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "Apache-2.0",
   "description": "Zustand adapter for json-render StateStore",
   "keywords": [


### PR DESCRIPTION
## Summary

Bump all `@json-render/*` packages to **0.19.1**, add the changelog entry (release-notes markers moved to the new section), and update the web app changelog page.

## Release contents

- zod 4.4+ compatibility: peer-only zod in core and shadcn-svelte (#297, #303)
- `visible` validation agreement across zod 4.x (#287, #299 — already on main)
- `autoFixSpec` prunes dangling `children` references (#300 — already on main)
- Buffer/stream type fixes in image and react-pdf (#304)
- harness-chat example (#302 — already on main)

## Merge order

⚠️ Merge **#303** and **#304** into main *before* this PR. The release workflow publishes on the version change when this lands, and #304 in particular fixes `build` failures in `@json-render/image`/`react-pdf` that would otherwise fail the publish job's `pnpm run build` step.

After merging this PR, the Release workflow compares `packages/core` version (0.19.1) to npm, publishes all public packages, and creates the `v0.19.1` GitHub release from the marked CHANGELOG section (extraction verified locally).