### PR TITLE
fix: numeric validator accepts '123abc', truncate exceeds maxLength

### DIFF
--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -153,7 +153,7 @@ export const builtInValidationFunctions: Record<string, ValidationFunction> = {
    */
   numeric: (value: unknown) => {
     if (typeof value === "number") return !isNaN(value);
-    if (typeof value === "string") return !isNaN(parseFloat(value));
+    if (typeof value === "string") return !isNaN(Number(value)) && isFinite(Number(value));
     return false;
   },
 

--- a/packages/directives/src/truncate.ts
+++ b/packages/directives/src/truncate.ts
@@ -16,6 +16,6 @@ export const truncateDirective = defineDirective({
     const suffix = raw.suffix ?? "...";
 
     if (text.length <= maxLength) return text;
-    return text.slice(0, maxLength) + suffix;
+    return text.slice(0, maxLength - suffix.length) + suffix;
   },
 });


### PR DESCRIPTION
Two bugs:

- the \`numeric\` validator was using \`parseFloat\` which parses \`"123abc"\` as \`123\` and passes validation. Users could submit \`"99bottles"\` and it would be accepted as a valid number. Changed to \`Number()\` which correctly returns \`NaN\` for strings with trailing non-numeric characters.

- the \`\$truncate\` directive was producing strings longer than \`maxLength\` because it did \`text.slice(0, maxLength) + suffix\` without accounting for the suffix length. So \`length: 50\` with a \`"..."\` suffix would produce a 53-character string. Changed to \`text.slice(0, maxLength - suffix.length)\` so the final output actually respects the limit.