### PR TITLE
feat(core): forward params to named onSuccess/onError actions

### DIFF
--- a/packages/core/src/actions.test.ts
+++ b/packages/core/src/actions.test.ts
@@ -161,7 +161,27 @@ describe("executeAction", () => {
       executeAction: executeActionFn,
     });
 
-    expect(executeActionFn).toHaveBeenCalledWith("followUp");
+    expect(executeActionFn).toHaveBeenCalledWith({ action: "followUp" });
+  });
+
+  it("handles onSuccess with action and params", async () => {
+    const executeActionFn = vi.fn();
+
+    await executeAction({
+      action: {
+        action: "save",
+        params: {},
+        onSuccess: { action: "toast", params: { message: "Saved" } },
+      },
+      handler: vi.fn().mockResolvedValue(undefined),
+      setState: vi.fn(),
+      executeAction: executeActionFn,
+    });
+
+    expect(executeActionFn).toHaveBeenCalledWith({
+      action: "toast",
+      params: { message: "Saved" },
+    });
   });
 
   it("handles onError with set", async () => {
@@ -196,7 +216,28 @@ describe("executeAction", () => {
       executeAction: executeActionFn,
     });
 
-    expect(executeActionFn).toHaveBeenCalledWith("handleError");
+    expect(executeActionFn).toHaveBeenCalledWith({ action: "handleError" });
+  });
+
+  it("handles onError with action and params", async () => {
+    const executeActionFn = vi.fn();
+    const error = new Error("Failed");
+
+    await executeAction({
+      action: {
+        action: "save",
+        params: {},
+        onError: { action: "toast", params: { message: "Save failed" } },
+      },
+      handler: vi.fn().mockRejectedValue(error),
+      setState: vi.fn(),
+      executeAction: executeActionFn,
+    });
+
+    expect(executeActionFn).toHaveBeenCalledWith({
+      action: "toast",
+      params: { message: "Save failed" },
+    });
   });
 
   it("re-throws error when no onError handler", async () => {

--- a/packages/core/src/actions.test.ts
+++ b/packages/core/src/actions.test.ts
@@ -4,7 +4,27 @@ import {
   executeAction,
   interpolateString,
   actionBinding,
+  ActionOnSuccessSchema,
+  ActionOnErrorSchema,
 } from "./actions";
+
+describe("onSuccess/onError schemas", () => {
+  it("keeps params on the onSuccess action form", () => {
+    const parsed = ActionOnSuccessSchema.parse({
+      action: "toast",
+      params: { message: "Saved" },
+    });
+    expect(parsed).toEqual({ action: "toast", params: { message: "Saved" } });
+  });
+
+  it("keeps params on the onError action form", () => {
+    const parsed = ActionOnErrorSchema.parse({
+      action: "toast",
+      params: { message: "Failed" },
+    });
+    expect(parsed).toEqual({ action: "toast", params: { message: "Failed" } });
+  });
+});
 
 describe("interpolateString", () => {
   it("interpolates ${path} expressions", () => {

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -19,14 +19,14 @@ export interface ActionConfirm {
 export type ActionOnSuccess =
   | { navigate: string }
   | { set: Record<string, unknown> }
-  | { action: string };
+  | { action: string; params?: Record<string, DynamicValue> };
 
 /**
  * Action error handler
  */
 export type ActionOnError =
   | { set: Record<string, unknown> }
-  | { action: string };
+  | { action: string; params?: Record<string, DynamicValue> };
 
 /**
  * Action binding — maps an event to an action invocation.
@@ -73,7 +73,10 @@ export const ActionConfirmSchema = z.object({
 export const ActionOnSuccessSchema = z.union([
   z.object({ navigate: z.string() }),
   z.object({ set: z.record(z.string(), z.unknown()) }),
-  z.object({ action: z.string() }),
+  z.object({
+    action: z.string(),
+    params: z.record(z.string(), DynamicValueSchema).optional(),
+  }),
 ]);
 
 /**
@@ -190,7 +193,7 @@ export interface ActionExecutionContext {
   /** Function to navigate */
   navigate?: (path: string) => void;
   /** Function to execute another action */
-  executeAction?: (name: string) => Promise<void>;
+  executeAction?: (name: string | ActionBinding) => Promise<void>;
 }
 
 /**
@@ -213,7 +216,7 @@ export async function executeAction(
           setState(path, value);
         }
       } else if ("action" in action.onSuccess && executeAction) {
-        await executeAction(action.onSuccess.action);
+        await executeAction(action.onSuccess);
       }
     }
   } catch (error) {
@@ -229,7 +232,7 @@ export async function executeAction(
           setState(path, resolvedValue);
         }
       } else if ("action" in action.onError && executeAction) {
-        await executeAction(action.onError.action);
+        await executeAction(action.onError);
       }
     } else {
       throw error;

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -196,7 +196,7 @@ export interface ActionExecutionContext {
   /** Function to navigate */
   navigate?: (path: string) => void;
   /** Function to execute another action */
-  executeAction?: (name: string | ActionBinding) => Promise<void>;
+  executeAction?: (binding: ActionBinding) => Promise<void>;
 }
 
 /**

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -84,7 +84,10 @@ export const ActionOnSuccessSchema = z.union([
  */
 export const ActionOnErrorSchema = z.union([
   z.object({ set: z.record(z.string(), z.unknown()) }),
-  z.object({ action: z.string() }),
+  z.object({
+    action: z.string(),
+    params: z.record(z.string(), DynamicValueSchema).optional(),
+  }),
 ]);
 
 /**

--- a/packages/ink/src/contexts/actions.tsx
+++ b/packages/ink/src/contexts/actions.tsx
@@ -280,8 +280,9 @@ export function ActionProvider({
           handler,
           setState: set,
           navigate: navigateRef.current,
-          executeAction: async (name) => {
-            const subBinding: ActionBinding = { action: name };
+          executeAction: async (binding) => {
+            const subBinding =
+              typeof binding === "string" ? { action: binding } : binding;
             await execute(subBinding);
           },
         });

--- a/packages/ink/src/contexts/actions.tsx
+++ b/packages/ink/src/contexts/actions.tsx
@@ -281,9 +281,7 @@ export function ActionProvider({
           setState: set,
           navigate: navigateRef.current,
           executeAction: async (binding) => {
-            const subBinding =
-              typeof binding === "string" ? { action: binding } : binding;
-            await execute(subBinding);
+            await execute(binding);
           },
         });
       } finally {

--- a/packages/react-email/src/contexts/actions.tsx
+++ b/packages/react-email/src/contexts/actions.tsx
@@ -175,9 +175,7 @@ export function ActionProvider({
               setState: set,
               navigate,
               executeAction: async (binding) => {
-                const subBinding =
-                  typeof binding === "string" ? { action: binding } : binding;
-                await execute(subBinding);
+                await execute(binding);
               },
             });
           } finally {
@@ -198,9 +196,7 @@ export function ActionProvider({
           setState: set,
           navigate,
           executeAction: async (binding) => {
-            const subBinding =
-              typeof binding === "string" ? { action: binding } : binding;
-            await execute(subBinding);
+            await execute(binding);
           },
         });
       } finally {

--- a/packages/react-email/src/contexts/actions.tsx
+++ b/packages/react-email/src/contexts/actions.tsx
@@ -174,8 +174,9 @@ export function ActionProvider({
               handler,
               setState: set,
               navigate,
-              executeAction: async (name) => {
-                const subBinding: ActionBinding = { action: name };
+              executeAction: async (binding) => {
+                const subBinding =
+                  typeof binding === "string" ? { action: binding } : binding;
                 await execute(subBinding);
               },
             });
@@ -196,8 +197,9 @@ export function ActionProvider({
           handler,
           setState: set,
           navigate,
-          executeAction: async (name) => {
-            const subBinding: ActionBinding = { action: name };
+          executeAction: async (binding) => {
+            const subBinding =
+              typeof binding === "string" ? { action: binding } : binding;
             await execute(subBinding);
           },
         });

--- a/packages/react-native/src/contexts/actions.tsx
+++ b/packages/react-native/src/contexts/actions.tsx
@@ -262,8 +262,9 @@ export function ActionProvider({
               handler,
               setState: set,
               navigate,
-              executeAction: async (name) => {
-                const subBinding: ActionBinding = { action: name };
+              executeAction: async (binding) => {
+                const subBinding =
+                  typeof binding === "string" ? { action: binding } : binding;
                 await execute(subBinding);
               },
             });
@@ -285,8 +286,9 @@ export function ActionProvider({
           handler,
           setState: set,
           navigate,
-          executeAction: async (name) => {
-            const subBinding: ActionBinding = { action: name };
+          executeAction: async (binding) => {
+            const subBinding =
+              typeof binding === "string" ? { action: binding } : binding;
             await execute(subBinding);
           },
         });

--- a/packages/react-native/src/contexts/actions.tsx
+++ b/packages/react-native/src/contexts/actions.tsx
@@ -263,9 +263,7 @@ export function ActionProvider({
               setState: set,
               navigate,
               executeAction: async (binding) => {
-                const subBinding =
-                  typeof binding === "string" ? { action: binding } : binding;
-                await execute(subBinding);
+                await execute(binding);
               },
             });
           } finally {
@@ -287,9 +285,7 @@ export function ActionProvider({
           setState: set,
           navigate,
           executeAction: async (binding) => {
-            const subBinding =
-              typeof binding === "string" ? { action: binding } : binding;
-            await execute(subBinding);
+            await execute(binding);
           },
         });
       } finally {

--- a/packages/react-pdf/src/contexts/actions.tsx
+++ b/packages/react-pdf/src/contexts/actions.tsx
@@ -176,8 +176,9 @@ export function ActionProvider({
               handler,
               setState: set,
               navigate,
-              executeAction: async (name) => {
-                const subBinding: ActionBinding = { action: name };
+              executeAction: async (binding) => {
+                const subBinding =
+                  typeof binding === "string" ? { action: binding } : binding;
                 await execute(subBinding);
               },
             });
@@ -198,8 +199,9 @@ export function ActionProvider({
           handler,
           setState: set,
           navigate,
-          executeAction: async (name) => {
-            const subBinding: ActionBinding = { action: name };
+          executeAction: async (binding) => {
+            const subBinding =
+              typeof binding === "string" ? { action: binding } : binding;
             await execute(subBinding);
           },
         });

--- a/packages/react-pdf/src/contexts/actions.tsx
+++ b/packages/react-pdf/src/contexts/actions.tsx
@@ -177,9 +177,7 @@ export function ActionProvider({
               setState: set,
               navigate,
               executeAction: async (binding) => {
-                const subBinding =
-                  typeof binding === "string" ? { action: binding } : binding;
-                await execute(subBinding);
+                await execute(binding);
               },
             });
           } finally {
@@ -200,9 +198,7 @@ export function ActionProvider({
           setState: set,
           navigate,
           executeAction: async (binding) => {
-            const subBinding =
-              typeof binding === "string" ? { action: binding } : binding;
-            await execute(subBinding);
+            await execute(binding);
           },
         });
       } finally {

--- a/packages/react/src/chained-actions.test.tsx
+++ b/packages/react/src/chained-actions.test.tsx
@@ -195,4 +195,46 @@ describe("chained actions: live $state resolution (#141)", () => {
     expect(state.counter).toBe(42);
     expect(state.counterCopy).toBe(42);
   });
+
+  it("forwards params to a named onSuccess action (#301)", async () => {
+    let receivedParams: Record<string, unknown> | undefined;
+    const handlers = {
+      save: async () => {},
+      toast: async (params: Record<string, unknown>) => {
+        receivedParams = params;
+      },
+    };
+
+    const spec: Spec = {
+      root: "main",
+      elements: {
+        main: {
+          type: "Button",
+          props: { label: "Save" },
+          on: {
+            press: {
+              action: "save",
+              onSuccess: { action: "toast", params: { message: "Saved!" } },
+            },
+          },
+        },
+      },
+    };
+
+    function App() {
+      return (
+        <JSONUIProvider registry={registry} handlers={handlers}>
+          <Renderer spec={spec} registry={registry} />
+        </JSONUIProvider>
+      );
+    }
+
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("btn"));
+    });
+
+    expect(receivedParams).toEqual({ message: "Saved!" });
+  });
 });

--- a/packages/react/src/contexts/actions.tsx
+++ b/packages/react/src/contexts/actions.tsx
@@ -309,8 +309,9 @@ export function ActionProvider({
                 handler,
                 setState: set,
                 navigate,
-                executeAction: async (name) => {
-                  const subBinding: ActionBinding = { action: name };
+                executeAction: async (binding) => {
+                  const subBinding =
+                    typeof binding === "string" ? { action: binding } : binding;
                   await execute(subBinding);
                 },
               });
@@ -332,8 +333,9 @@ export function ActionProvider({
             handler,
             setState: set,
             navigate,
-            executeAction: async (name) => {
-              const subBinding: ActionBinding = { action: name };
+            executeAction: async (binding) => {
+              const subBinding =
+                typeof binding === "string" ? { action: binding } : binding;
               await execute(subBinding);
             },
           });

--- a/packages/react/src/contexts/actions.tsx
+++ b/packages/react/src/contexts/actions.tsx
@@ -310,9 +310,7 @@ export function ActionProvider({
                 setState: set,
                 navigate,
                 executeAction: async (binding) => {
-                  const subBinding =
-                    typeof binding === "string" ? { action: binding } : binding;
-                  await execute(subBinding);
+                  await execute(binding);
                 },
               });
             } finally {
@@ -334,9 +332,7 @@ export function ActionProvider({
             setState: set,
             navigate,
             executeAction: async (binding) => {
-              const subBinding =
-                typeof binding === "string" ? { action: binding } : binding;
-              await execute(subBinding);
+              await execute(binding);
             },
           });
         } finally {

--- a/packages/solid/src/contexts/actions.tsx
+++ b/packages/solid/src/contexts/actions.tsx
@@ -240,9 +240,7 @@ export function ActionProvider(props: ParentProps<ActionProviderProps>) {
               setState: set,
               navigate: props.navigate,
               executeAction: async (binding) => {
-                const subBinding =
-                  typeof binding === "string" ? { action: binding } : binding;
-                await execute(subBinding);
+                await execute(binding);
               },
             });
           } finally {
@@ -263,9 +261,7 @@ export function ActionProvider(props: ParentProps<ActionProviderProps>) {
           setState: set,
           navigate: props.navigate,
           executeAction: async (binding) => {
-            const subBinding =
-              typeof binding === "string" ? { action: binding } : binding;
-            await execute(subBinding);
+            await execute(binding);
           },
         });
       } finally {

--- a/packages/solid/src/contexts/actions.tsx
+++ b/packages/solid/src/contexts/actions.tsx
@@ -239,8 +239,9 @@ export function ActionProvider(props: ParentProps<ActionProviderProps>) {
               handler,
               setState: set,
               navigate: props.navigate,
-              executeAction: async (name: string) => {
-                const subBinding: ActionBinding = { action: name };
+              executeAction: async (binding) => {
+                const subBinding =
+                  typeof binding === "string" ? { action: binding } : binding;
                 await execute(subBinding);
               },
             });
@@ -261,8 +262,9 @@ export function ActionProvider(props: ParentProps<ActionProviderProps>) {
           handler,
           setState: set,
           navigate: props.navigate,
-          executeAction: async (name: string) => {
-            const subBinding: ActionBinding = { action: name };
+          executeAction: async (binding) => {
+            const subBinding =
+              typeof binding === "string" ? { action: binding } : binding;
             await execute(subBinding);
           },
         });

--- a/packages/svelte/src/contexts/ActionProvider.svelte
+++ b/packages/svelte/src/contexts/ActionProvider.svelte
@@ -304,8 +304,9 @@
             handler,
             setState: stateCtx.set,
             navigate,
-            executeAction: async (name) => {
-              const subBinding: CoreActionBinding = { action: name };
+            executeAction: async (binding) => {
+              const subBinding: CoreActionBinding =
+                typeof binding === "string" ? { action: binding } : binding;
               await execute(subBinding);
             },
           });
@@ -322,8 +323,9 @@
         handler,
         setState: stateCtx.set,
         navigate,
-        executeAction: async (name) => {
-          const subBinding: CoreActionBinding = { action: name };
+        executeAction: async (binding) => {
+          const subBinding: CoreActionBinding =
+            typeof binding === "string" ? { action: binding } : binding;
           await execute(subBinding);
         },
       });

--- a/packages/svelte/src/contexts/ActionProvider.svelte
+++ b/packages/svelte/src/contexts/ActionProvider.svelte
@@ -305,9 +305,7 @@
             setState: stateCtx.set,
             navigate,
             executeAction: async (binding) => {
-              const subBinding: CoreActionBinding =
-                typeof binding === "string" ? { action: binding } : binding;
-              await execute(subBinding);
+              await execute(binding);
             },
           });
         } finally {
@@ -324,9 +322,7 @@
         setState: stateCtx.set,
         navigate,
         executeAction: async (binding) => {
-          const subBinding: CoreActionBinding =
-            typeof binding === "string" ? { action: binding } : binding;
-          await execute(subBinding);
+          await execute(binding);
         },
       });
     } finally {

--- a/packages/svelte/src/contexts/actions.test.ts
+++ b/packages/svelte/src/contexts/actions.test.ts
@@ -180,6 +180,56 @@ describe("createActionContext", () => {
   );
 
   it(
+    "forwards params to a named onSuccess action (#301)",
+    (() => {
+      const toast = vi.fn().mockResolvedValue(undefined);
+      return component(
+        async () => {
+          const actionCtx = getActionContext();
+
+          await actionCtx.execute({
+            action: "save",
+            onSuccess: { action: "toast", params: { message: "Saved" } },
+          });
+
+          expect(toast).toHaveBeenCalledWith({ message: "Saved" });
+        },
+        {
+          handlers: {
+            save: vi.fn().mockResolvedValue(undefined),
+            toast,
+          },
+        },
+      );
+    })(),
+  );
+
+  it(
+    "forwards params to a named onError action (#301)",
+    (() => {
+      const toast = vi.fn().mockResolvedValue(undefined);
+      return component(
+        async () => {
+          const actionCtx = getActionContext();
+
+          await actionCtx.execute({
+            action: "save",
+            onError: { action: "toast", params: { message: "Failed" } },
+          });
+
+          expect(toast).toHaveBeenCalledWith({ message: "Failed" });
+        },
+        {
+          handlers: {
+            save: vi.fn().mockRejectedValue(new Error("boom")),
+            toast,
+          },
+        },
+      );
+    })(),
+  );
+
+  it(
     "warns when no handler registered",
     component(async () => {
       const actionCtx = getActionContext();

--- a/packages/vue/src/composables/actions.ts
+++ b/packages/vue/src/composables/actions.ts
@@ -287,8 +287,9 @@ export const ActionProvider = defineComponent({
               handler,
               setState: set,
               navigate: props.navigate,
-              executeAction: async (name) => {
-                const subBinding: ActionBinding = { action: name };
+              executeAction: async (binding) => {
+                const subBinding =
+                  typeof binding === "string" ? { action: binding } : binding;
                 await execute(subBinding);
               },
             });
@@ -310,8 +311,9 @@ export const ActionProvider = defineComponent({
             handler,
             setState: set,
             navigate: props.navigate,
-            executeAction: async (name) => {
-              const subBinding: ActionBinding = { action: name };
+            executeAction: async (binding) => {
+              const subBinding =
+                typeof binding === "string" ? { action: binding } : binding;
               await execute(subBinding);
             },
           });

--- a/packages/vue/src/composables/actions.ts
+++ b/packages/vue/src/composables/actions.ts
@@ -288,9 +288,7 @@ export const ActionProvider = defineComponent({
               setState: set,
               navigate: props.navigate,
               executeAction: async (binding) => {
-                const subBinding =
-                  typeof binding === "string" ? { action: binding } : binding;
-                await execute(subBinding);
+                await execute(binding);
               },
             });
           } finally {
@@ -312,9 +310,7 @@ export const ActionProvider = defineComponent({
             setState: set,
             navigate: props.navigate,
             executeAction: async (binding) => {
-              const subBinding =
-                typeof binding === "string" ? { action: binding } : binding;
-              await execute(subBinding);
+              await execute(binding);
             },
           });
         } finally {


### PR DESCRIPTION
`onSuccess` and `onError` can run a registered handler by name via `{ action: "<name>" }`, but only the name was forwarded, so `params` never reached the handler. A chained `onSuccess: { action: "toast", params: { message } }` silently fell back to the handler's defaults, even though top-level bindings already resolve `params`. This closes that gap.

Params were dropped in three places, now all fixed:
- the schema stripped `params` from the `{ action }` form during validation, on both `ActionOnSuccessSchema` and `ActionOnErrorSchema`
- the core executor forwarded only the name
- each renderer bridge rebuilt `{ action: name }` from that name (react, solid, vue, react-native, react-pdf, react-email, ink, svelte)

The fix forwards the whole binding: `params` is added to the `{ action }` form in both schemas and their hand-written types, and the executor passes `action.onSuccess` / `action.onError`.

The `executeAction` context callback is now typed `(binding: ActionBinding)` instead of `(name: string)`. Core always passes the resolved binding, so this makes the contract honest and lets every renderer bridge collapse to `execute(binding)`. This is a breaking change for anyone implementing a custom renderer bridge that expected a bare string, now surfaced at compile time rather than silently at runtime. `navigate` and `set` handlers are unaffected.

Tests: core unit tests cover the executor and both schemas; react and svelte integration tests render a real component, fire the event, and assert the named onSuccess and onError handlers receive their `params`. Each was verified to fail without the fix.

Closes #301