### PR TITLE
fix(examples): correct Tailwind @source paths in chat and harness-chat

### DIFF
--- a/examples/chat/app/globals.css
+++ b/examples/chat/app/globals.css
@@ -1,7 +1,8 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@source "../../../node_modules/streamdown/dist/*.js";
+@source "../node_modules/streamdown/dist/*.js";
+@source "../../../packages/shadcn/src/**/*.tsx";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/examples/harness-chat/app/globals.css
+++ b/examples/harness-chat/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@source "../../../node_modules/streamdown/dist/*.js";
+@source "../node_modules/streamdown/dist/*.js";
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
Fixes #312

### What

- `examples/chat/app/globals.css`: add `@source "../../../packages/shadcn/src/**/*.tsx"`, matching `no-ai`, `next-website-builder`, and `mcp`, so catalog-only utilities are generated
- `chat` and `harness-chat`: fix the streamdown `@source` path from `../../../node_modules/...` (repo root, empty under pnpm) to `../node_modules/...`, matching `apps/web`

### Why

Tailwind v4 skips `node_modules` and gitignored `dist` when scanning sources, so classes that only exist in the built `@json-render/shadcn` package never reach the generated CSS. A `Grid` with `columns: 4` renders correct DOM with dead class names.

### Testing

Prompted the chat example for a 4x4 card grid and a `justify="around"` stack. `grid-cols-1..6` and `justify-around` now appear in the served CSS and layouts render correctly.
