### PR TITLE
feat(react-native): support custom directives

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -195,6 +195,29 @@ Any prop value can be a dynamic expression resolved at render time:
 
 See [@json-render/core](../core/README.md) for full expression syntax.
 
+### Custom directives
+
+Register custom directives through `JSONUIProvider` to resolve user-defined `$`-prefixed values in component props:
+
+```tsx
+import { defineDirective, resolvePropValue } from "@json-render/core";
+import { z } from "zod";
+
+const uppercase = defineDirective({
+  name: "$uppercase",
+  schema: z.object({ $uppercase: z.unknown() }),
+  resolve(value, ctx) {
+    return String(resolvePropValue(value.$uppercase, ctx)).toUpperCase();
+  },
+});
+
+<JSONUIProvider directives={[uppercase]}>
+  <Renderer spec={spec} />
+</JSONUIProvider>;
+```
+
+Directives can wrap built-in expressions such as `{ "$uppercase": { "$state": "/message" } }`. See the [directives documentation](https://json-render.dev/docs/directives) for more details.
+
 ## Tab Navigation Pattern
 
 Combine `Pressable`, `setState`, visibility conditions, and dynamic props for functional tabs:

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -215,20 +215,55 @@ Register custom directives through `JSONUIProvider` or a component returned by `
 import { defineDirective, resolvePropValue } from "@json-render/core";
 import { z } from "zod";
 
-const uppercase = defineDirective({
-  name: "$uppercase",
-  schema: z.object({ $uppercase: z.unknown() }),
+const math = defineDirective({
+  name: "$math",
+  schema: z.object({
+    $math: z.literal("multiply"),
+    a: z.unknown(),
+    b: z.unknown(),
+  }),
   resolve(value, ctx) {
-    return String(resolvePropValue(value.$uppercase, ctx)).toUpperCase();
+    return Number(resolvePropValue(value.a, ctx)) *
+      Number(resolvePropValue(value.b, ctx));
   },
 });
 
-<JSONUIProvider directives={[uppercase]}>
+const format = defineDirective({
+  name: "$format",
+  schema: z.object({
+    $format: z.literal("currency"),
+    value: z.unknown(),
+    currency: z.string(),
+  }),
+  resolve(value, ctx) {
+    const amount = Number(resolvePropValue(value.value, ctx));
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: value.currency,
+    }).format(amount);
+  },
+});
+
+<JSONUIProvider directives={[math, format]}>
   <Renderer spec={spec} />
 </JSONUIProvider>;
 ```
 
-Directives can wrap built-in expressions such as `{ "$uppercase": { "$state": "/message" } }`. See the [directives documentation](https://json-render.dev/docs/directives) for more details.
+The directives compose in props, so `$format` can format a `$math` result that reads its operands from state:
+
+```json
+{
+  "$format": "currency",
+  "value": {
+    "$math": "multiply",
+    "a": { "$state": "/price" },
+    "b": { "$state": "/qty" }
+  },
+  "currency": "USD"
+}
+```
+
+See the [directives documentation](https://json-render.dev/docs/directives) for more details.
 
 ## Tab Navigation Pattern
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -197,7 +197,7 @@ See [@json-render/core](../core/README.md) for full expression syntax.
 
 ### Custom directives
 
-Register custom directives through `JSONUIProvider` to resolve user-defined `$`-prefixed values in component props:
+Register custom directives through `JSONUIProvider` or a component returned by `createRenderer` to resolve user-defined `$`-prefixed values in component props:
 
 ```tsx
 import { defineDirective, resolvePropValue } from "@json-render/core";

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -195,6 +195,18 @@ Any prop value can be a dynamic expression resolved at render time:
 
 See [@json-render/core](../core/README.md) for full expression syntax.
 
+### Computed functions
+
+Register named functions through `JSONUIProvider` or a component returned by `createRenderer` to resolve `$computed` expressions:
+
+```tsx
+<JSONUIProvider
+  functions={{ fullName: (args) => `${args.first} ${args.last}` }}
+>
+  <Renderer spec={spec} />
+</JSONUIProvider>
+```
+
 ### Custom directives
 
 Register custom directives through `JSONUIProvider` or a component returned by `createRenderer` to resolve user-defined `$`-prefixed values in component props:

--- a/packages/react-native/src/renderer.tsx
+++ b/packages/react-native/src/renderer.tsx
@@ -12,6 +12,7 @@ import type {
   Catalog,
   SchemaDefinition,
   StateStore,
+  ComputedFunction,
   DirectiveDefinition,
   DirectiveRegistry,
 } from "@json-render/core";
@@ -42,6 +43,15 @@ import { ValidationProvider } from "./contexts/validation";
 import { ConfirmDialog } from "./contexts/actions";
 import { standardComponents } from "./components/standard";
 import { RepeatScopeProvider, useRepeatScope } from "./contexts/repeat-scope";
+
+const EMPTY_FUNCTIONS: Record<string, ComputedFunction> = {};
+
+const FunctionsContext =
+  React.createContext<Record<string, ComputedFunction>>(EMPTY_FUNCTIONS);
+
+function useFunctions(): Record<string, ComputedFunction> {
+  return React.useContext(FunctionsContext);
+}
 
 const DirectivesContext = React.createContext<DirectiveRegistry | undefined>(
   undefined,
@@ -170,6 +180,7 @@ const ElementRenderer = React.memo(function ElementRenderer({
   const { ctx } = useVisibility();
   const { execute } = useActions();
   const { getSnapshot } = useStateStore();
+  const functions = useFunctions();
   const directives = useDirectives();
 
   // Build context with repeat scope (used for both visibility and props)
@@ -181,10 +192,11 @@ const ElementRenderer = React.memo(function ElementRenderer({
             repeatItem: repeatScope.item,
             repeatIndex: repeatScope.index,
             repeatBasePath: repeatScope.basePath,
+            functions,
             directives,
           }
-        : { ...ctx, directives },
-    [ctx, repeatScope, directives],
+        : { ...ctx, functions, directives },
+    [ctx, repeatScope, functions, directives],
   );
 
   // Evaluate visibility (now supports $item/$index inside repeat scopes)
@@ -452,6 +464,8 @@ export interface JSONUIProviderProps {
     string,
     (value: unknown, args?: Record<string, unknown>) => boolean
   >;
+  /** Named functions for `$computed` expressions in props */
+  functions?: Record<string, ComputedFunction>;
   /** Custom directives for user-defined `$`-prefixed dynamic values */
   directives?: DirectiveDefinition[];
   /** Callback when state changes (uncontrolled mode) */
@@ -469,6 +483,7 @@ export function JSONUIProvider({
   handlers,
   navigate,
   validationFunctions,
+  functions,
   directives,
   onStateChange,
   children,
@@ -486,12 +501,14 @@ export function JSONUIProvider({
     >
       <VisibilityProvider>
         <ActionProvider handlers={handlers} navigate={navigate}>
-          <DirectivesContext.Provider value={directiveRegistry}>
-            <ValidationProvider customFunctions={validationFunctions}>
-              {children}
-              <ConfirmationDialogManager />
-            </ValidationProvider>
-          </DirectivesContext.Provider>
+          <FunctionsContext.Provider value={functions ?? EMPTY_FUNCTIONS}>
+            <DirectivesContext.Provider value={directiveRegistry}>
+              <ValidationProvider customFunctions={validationFunctions}>
+                {children}
+                <ConfirmationDialogManager />
+              </ValidationProvider>
+            </DirectivesContext.Provider>
+          </FunctionsContext.Provider>
         </ActionProvider>
       </VisibilityProvider>
     </StateProvider>
@@ -686,6 +703,8 @@ export interface CreateRendererProps {
   onAction?: (actionName: string, params?: Record<string, unknown>) => void;
   /** Callback when state changes (uncontrolled mode) */
   onStateChange?: (changes: Array<{ path: string; value: unknown }>) => void;
+  /** Named functions for `$computed` expressions in props */
+  functions?: Record<string, ComputedFunction>;
   /** Custom directives for user-defined `$`-prefixed dynamic values */
   directives?: DirectiveDefinition[];
   /** Whether the spec is currently loading/streaming */
@@ -741,6 +760,7 @@ export function createRenderer<
     state,
     onAction,
     onStateChange,
+    functions,
     directives,
     loading,
     fallback,
@@ -775,17 +795,19 @@ export function createRenderer<
       >
         <VisibilityProvider>
           <ActionProvider handlers={actionHandlers}>
-            <DirectivesContext.Provider value={directiveRegistry}>
-              <ValidationProvider>
-                <Renderer
-                  spec={spec}
-                  registry={registry}
-                  loading={loading}
-                  fallback={fallback}
-                />
-                <ConfirmationDialogManager />
-              </ValidationProvider>
-            </DirectivesContext.Provider>
+            <FunctionsContext.Provider value={functions ?? EMPTY_FUNCTIONS}>
+              <DirectivesContext.Provider value={directiveRegistry}>
+                <ValidationProvider>
+                  <Renderer
+                    spec={spec}
+                    registry={registry}
+                    loading={loading}
+                    fallback={fallback}
+                  />
+                  <ConfirmationDialogManager />
+                </ValidationProvider>
+              </DirectivesContext.Provider>
+            </FunctionsContext.Provider>
           </ActionProvider>
         </VisibilityProvider>
       </StateProvider>

--- a/packages/react-native/src/renderer.tsx
+++ b/packages/react-native/src/renderer.tsx
@@ -686,6 +686,8 @@ export interface CreateRendererProps {
   onAction?: (actionName: string, params?: Record<string, unknown>) => void;
   /** Callback when state changes (uncontrolled mode) */
   onStateChange?: (changes: Array<{ path: string; value: unknown }>) => void;
+  /** Custom directives for user-defined `$`-prefixed dynamic values */
+  directives?: DirectiveDefinition[];
   /** Whether the spec is currently loading/streaming */
   loading?: boolean;
   /** Fallback component for unknown types */
@@ -739,9 +741,15 @@ export function createRenderer<
     state,
     onAction,
     onStateChange,
+    directives,
     loading,
     fallback,
   }: CreateRendererProps) {
+    const directiveRegistry = useMemo(
+      () => (directives ? createDirectiveRegistry(directives) : undefined),
+      [directives],
+    );
+
     // Wrap onAction with a Proxy so any action name routes to the callback
     const actionHandlers = onAction
       ? new Proxy(
@@ -767,15 +775,17 @@ export function createRenderer<
       >
         <VisibilityProvider>
           <ActionProvider handlers={actionHandlers}>
-            <ValidationProvider>
-              <Renderer
-                spec={spec}
-                registry={registry}
-                loading={loading}
-                fallback={fallback}
-              />
-              <ConfirmationDialogManager />
-            </ValidationProvider>
+            <DirectivesContext.Provider value={directiveRegistry}>
+              <ValidationProvider>
+                <Renderer
+                  spec={spec}
+                  registry={registry}
+                  loading={loading}
+                  fallback={fallback}
+                />
+                <ConfirmationDialogManager />
+              </ValidationProvider>
+            </DirectivesContext.Provider>
           </ActionProvider>
         </VisibilityProvider>
       </StateProvider>

--- a/packages/react-native/src/renderer.tsx
+++ b/packages/react-native/src/renderer.tsx
@@ -12,6 +12,8 @@ import type {
   Catalog,
   SchemaDefinition,
   StateStore,
+  DirectiveDefinition,
+  DirectiveRegistry,
 } from "@json-render/core";
 import {
   resolveElementProps,
@@ -19,6 +21,7 @@ import {
   resolveActionParam,
   evaluateVisibility,
   getByPath,
+  createDirectiveRegistry,
   type PropResolutionContext,
   type VisibilityContext as CoreVisibilityContext,
 } from "@json-render/core";
@@ -39,6 +42,14 @@ import { ValidationProvider } from "./contexts/validation";
 import { ConfirmDialog } from "./contexts/actions";
 import { standardComponents } from "./components/standard";
 import { RepeatScopeProvider, useRepeatScope } from "./contexts/repeat-scope";
+
+const DirectivesContext = React.createContext<DirectiveRegistry | undefined>(
+  undefined,
+);
+
+function useDirectives(): DirectiveRegistry | undefined {
+  return React.useContext(DirectivesContext);
+}
 
 /**
  * Props passed to component renderers
@@ -159,6 +170,7 @@ const ElementRenderer = React.memo(function ElementRenderer({
   const { ctx } = useVisibility();
   const { execute } = useActions();
   const { getSnapshot } = useStateStore();
+  const directives = useDirectives();
 
   // Build context with repeat scope (used for both visibility and props)
   const fullCtx: PropResolutionContext = useMemo(
@@ -169,9 +181,10 @@ const ElementRenderer = React.memo(function ElementRenderer({
             repeatItem: repeatScope.item,
             repeatIndex: repeatScope.index,
             repeatBasePath: repeatScope.basePath,
+            directives,
           }
-        : ctx,
-    [ctx, repeatScope],
+        : { ...ctx, directives },
+    [ctx, repeatScope, directives],
   );
 
   // Evaluate visibility (now supports $item/$index inside repeat scopes)
@@ -439,6 +452,8 @@ export interface JSONUIProviderProps {
     string,
     (value: unknown, args?: Record<string, unknown>) => boolean
   >;
+  /** Custom directives for user-defined `$`-prefixed dynamic values */
+  directives?: DirectiveDefinition[];
   /** Callback when state changes (uncontrolled mode) */
   onStateChange?: (changes: Array<{ path: string; value: unknown }>) => void;
   children: ReactNode;
@@ -454,9 +469,15 @@ export function JSONUIProvider({
   handlers,
   navigate,
   validationFunctions,
+  directives,
   onStateChange,
   children,
 }: JSONUIProviderProps) {
+  const directiveRegistry = useMemo(
+    () => (directives ? createDirectiveRegistry(directives) : undefined),
+    [directives],
+  );
+
   return (
     <StateProvider
       store={store}
@@ -465,10 +486,12 @@ export function JSONUIProvider({
     >
       <VisibilityProvider>
         <ActionProvider handlers={handlers} navigate={navigate}>
-          <ValidationProvider customFunctions={validationFunctions}>
-            {children}
-            <ConfirmationDialogManager />
-          </ValidationProvider>
+          <DirectivesContext.Provider value={directiveRegistry}>
+            <ValidationProvider customFunctions={validationFunctions}>
+              {children}
+              <ConfirmationDialogManager />
+            </ValidationProvider>
+          </DirectivesContext.Provider>
         </ActionProvider>
       </VisibilityProvider>
     </StateProvider>

--- a/skills/react-native/SKILL.md
+++ b/skills/react-native/SKILL.md
@@ -131,6 +131,10 @@ Any prop value can be a data-driven expression resolved at render time:
 
 Components do not use a `statePath` prop for two-way binding. Use `{ "$bindState": "/path" }` on the natural value prop instead.
 
+### Computed functions
+
+Pass named functions to `JSONUIProvider` or a component returned by `createRenderer` with the `functions` prop. These functions resolve `$computed` expressions in element props.
+
 ### Custom directives
 
 Pass custom directive definitions to `JSONUIProvider` or a component returned by `createRenderer` with the `directives` prop. Their resolvers can compose with built-in dynamic values such as `$state`:

--- a/skills/react-native/SKILL.md
+++ b/skills/react-native/SKILL.md
@@ -133,7 +133,7 @@ Components do not use a `statePath` prop for two-way binding. Use `{ "$bindState
 
 ### Custom directives
 
-Pass custom directive definitions to `JSONUIProvider` with the `directives` prop. Their resolvers can compose with built-in dynamic values such as `$state`:
+Pass custom directive definitions to `JSONUIProvider` or a component returned by `createRenderer` with the `directives` prop. Their resolvers can compose with built-in dynamic values such as `$state`:
 
 ```tsx
 <JSONUIProvider directives={[uppercaseDirective]}>

--- a/skills/react-native/SKILL.md
+++ b/skills/react-native/SKILL.md
@@ -131,6 +131,16 @@ Any prop value can be a data-driven expression resolved at render time:
 
 Components do not use a `statePath` prop for two-way binding. Use `{ "$bindState": "/path" }` on the natural value prop instead.
 
+### Custom directives
+
+Pass custom directive definitions to `JSONUIProvider` with the `directives` prop. Their resolvers can compose with built-in dynamic values such as `$state`:
+
+```tsx
+<JSONUIProvider directives={[uppercaseDirective]}>
+  <Renderer spec={spec} />
+</JSONUIProvider>
+```
+
 ## Built-in Actions
 
 The `setState` action is handled automatically by `ActionProvider` and updates the state model directly, which re-evaluates visibility conditions and dynamic prop expressions:


### PR DESCRIPTION
### What

- add a `directives` prop to React Native's `JSONUIProvider`
- register custom directives once per directives array and expose the registry to prop resolution, including repeat scopes
- document React Native directive registration in the package README and agent skill

### Why

`@json-render/react` supports custom directives, but `@json-render/react-native` cannot currently pass a directive registry into `resolveElementProps`. This brings the React Native renderer to parity so custom `$`-prefixed dynamic values can compose with built-in expressions such as `$state`.

### Testing

- `pnpm type-check` — 59/59 workspace tasks passed on Node 24.12.0 and pnpm 11.1.3
- `pnpm exec prettier --check packages/react-native/src/renderer.tsx`
- manually integrated the packaged change into a dummy screen and verified an `$uppercase` directive wrapping `$state` rendered `directives are working` as `DIRECTIVES ARE WORKING`

### Composed directive example

This parity example registers both directives with `defineDirective`. Each resolver calls `resolvePropValue`, so `$format` can consume the result of `$math`, while `$math` resolves its operands from `$state`:

```tsx
const mathDirective = defineDirective({
  name: "$math",
  schema: z.object({
    $math: z.literal("multiply"),
    a: z.unknown(),
    b: z.unknown(),
  }),
  resolve(value, ctx) {
    return (
      Number(resolvePropValue(value.a, ctx)) *
      Number(resolvePropValue(value.b, ctx))
    );
  },
});

const formatDirective = defineDirective({
  name: "$format",
  schema: z.object({
    $format: z.literal("currency"),
    value: z.unknown(),
    currency: z.string(),
  }),
  resolve(value, ctx) {
    const amount = Number(resolvePropValue(value.value, ctx));
    return new Intl.NumberFormat("en-US", {
      style: "currency",
      currency: value.currency,
    }).format(amount);
  },
});

<JSONUIProvider directives={[mathDirective, formatDirective]}>
  <Renderer spec={directiveTestSpec} />
</JSONUIProvider>
```

Mock spec:

```json
{
  "root": "directive-test",
  "state": {
    "price": 12.5,
    "qty": 2
  },
  "elements": {
    "directive-test": {
      "type": "Text",
      "props": {
        "text": {
          "$format": "currency",
          "value": {
            "$math": "multiply",
            "a": { "$state": "/price" },
            "b": { "$state": "/qty" }
          },
          "currency": "USD"
        }
      },
      "children": []
    }
  }
}
```

With `price: 12.5` and `qty: 2`, the resolved text is `$25.00`.

### Functions and directives parity

React Native now matches `@json-render/react` for both entry points:

- `JSONUIProvider` accepts `functions` and `directives`.
- Components returned by `createRenderer` accept `functions` and `directives`.
- Both paths provide `FunctionsContext` and a memoized `DirectivesContext` registry to element prop resolution, including repeat scopes.

- Programmatically verified the composed mock resolves to `$25.00` with `price: 12.5` and `qty: 2`.