### PR TITLE
fix(core): support numeric strings in min and max validation

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -601,8 +601,8 @@ Watchers only fire on value changes, not on initial render. Multiple action bind
 | `numeric` | Must be a number | — |
 | `minLength` | Minimum string length | `{ min: number }` |
 | `maxLength` | Maximum string length | `{ max: number }` |
-| `min` | Minimum numeric value | `{ min: number }` |
-| `max` | Maximum numeric value | `{ max: number }` |
+| `min` | Minimum value for numbers and numeric strings | `{ min: number }` |
+| `max` | Maximum value for numbers and numeric strings | `{ max: number }` |
 | `pattern` | Must match regex | `{ pattern: string }` |
 | `matches` | Must equal another field | `{ other: { $state: "/path" } }` |
 | `equalTo` | Alias for matches | `{ other: { $state: "/path" } }` |

--- a/packages/core/src/validation.test.ts
+++ b/packages/core/src/validation.test.ts
@@ -110,28 +110,54 @@ describe("builtInValidationFunctions", () => {
   });
 
   describe("min", () => {
-    it("passes when number meets minimum", () => {
+    it("passes when a number or numeric string meets the minimum", () => {
       expect(builtInValidationFunctions.min(5, { min: 3 })).toBe(true);
       expect(builtInValidationFunctions.min(3, { min: 3 })).toBe(true);
+      expect(builtInValidationFunctions.min("5", { min: 3 })).toBe(true);
+      expect(builtInValidationFunctions.min("3", { min: 3 })).toBe(true);
     });
 
-    it("fails when number is below minimum", () => {
+    it("fails when a number or numeric string is below the minimum", () => {
       expect(builtInValidationFunctions.min(2, { min: 3 })).toBe(false);
+      expect(builtInValidationFunctions.min("2", { min: 3 })).toBe(false);
     });
 
-    it("fails for non-numbers", () => {
-      expect(builtInValidationFunctions.min("5", { min: 3 })).toBe(false);
+    it.each(["", " ", "5px", null, false, NaN, Infinity])(
+      "fails for non-numeric value %j",
+      (value) => {
+        expect(builtInValidationFunctions.min(value, { min: 3 })).toBe(false);
+      },
+    );
+
+    it("fails when min is missing or not a number", () => {
+      expect(builtInValidationFunctions.min(5, { min: "3" })).toBe(false);
+      expect(builtInValidationFunctions.min(5, {})).toBe(false);
     });
   });
 
   describe("max", () => {
-    it("passes when number meets maximum", () => {
+    it("passes when a number or numeric string meets the maximum", () => {
       expect(builtInValidationFunctions.max(3, { max: 5 })).toBe(true);
       expect(builtInValidationFunctions.max(5, { max: 5 })).toBe(true);
+      expect(builtInValidationFunctions.max("3", { max: 5 })).toBe(true);
+      expect(builtInValidationFunctions.max("5", { max: 5 })).toBe(true);
     });
 
-    it("fails when number exceeds maximum", () => {
+    it("fails when a number or numeric string exceeds the maximum", () => {
       expect(builtInValidationFunctions.max(6, { max: 5 })).toBe(false);
+      expect(builtInValidationFunctions.max("6", { max: 5 })).toBe(false);
+    });
+
+    it.each(["", " ", "5px", null, false, NaN, Infinity])(
+      "fails for non-numeric value %j",
+      (value) => {
+        expect(builtInValidationFunctions.max(value, { max: 5 })).toBe(false);
+      },
+    );
+
+    it("fails when max is missing or not a number", () => {
+      expect(builtInValidationFunctions.max(5, { max: "5" })).toBe(false);
+      expect(builtInValidationFunctions.max(5, {})).toBe(false);
     });
   });
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -72,6 +72,15 @@ const matchesImpl: ValidationFunction = (
   return value === other;
 };
 
+const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
 /**
  * Built-in validation functions
  */
@@ -132,20 +141,22 @@ export const builtInValidationFunctions: Record<string, ValidationFunction> = {
    * Check minimum numeric value
    */
   min: (value: unknown, args?: Record<string, unknown>) => {
-    if (typeof value !== "number") return false;
+    const number = toFiniteNumber(value);
+    if (number === null) return false;
     const min = args?.min;
     if (typeof min !== "number") return false;
-    return value >= min;
+    return number >= min;
   },
 
   /**
    * Check maximum numeric value
    */
   max: (value: unknown, args?: Record<string, unknown>) => {
-    if (typeof value !== "number") return false;
+    const number = toFiniteNumber(value);
+    if (number === null) return false;
     const max = args?.max;
     if (typeof max !== "number") return false;
-    return value <= max;
+    return number <= max;
   },
 
   /**


### PR DESCRIPTION
## Summary

- Allow the built-in `min` and `max` validators to evaluate finite numeric strings.
- Continue rejecting empty strings, whitespace, non-numeric strings, booleans, `NaN`, and `Infinity`.
- Document the updated range validation behavior.

## Motivation

HTML inputs store their values as strings, including `<input type="number">`. The shadcn renderer therefore writes values such as `"12"` to state.

The built-in `min` and `max` validators currently accept only JavaScript numbers, so a valid number input can fail both range checks:

```ts
builtInValidationFunctions.min("12", { min: 0 }); // false
builtInValidationFunctions.max("12", { max: 120 }); // false
```

This change safely converts non-empty numeric strings before comparison while avoiding broad JavaScript coercion for values such as `""`, `false`, or `null`.

Related but non-overlapping: #306 tightens the standalone `numeric` validator. This PR only addresses range validation for input values.

## Testing

- `vitest run packages/core/src/validation.test.ts --environment node --maxWorkers 1` — 103 tests passed
- `pnpm --filter @json-render/core build`
- Prettier check for the changed TypeScript files
