### PR TITLE
chore(release): prepare v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,39 @@
 # Changelog
 
-## 0.19.0
+## 0.20.0
 
 <!-- release:start -->
+
+### New Features
+
+- **Named slots for React:** Components can declare named slots such as `header` and `footer`, while `children` remains the default slot. Slots are preserved through validation, streaming, nested conversion, code export, playground views, and Devtools navigation (#320). Built from the original contribution by @wotnak in #105
+- **Nested repeats:** `repeat.statePath` now accepts item-relative paths such as `{ "$item": "employees" }`, enabling nested data rendering across React, React Native, React Email, React PDF, Image, Ink, Solid, Svelte, and Vue (#319). Built from the original contribution by @tmchow in #256
+- **Harness chat example:** Added a complete Next.js example using the AI SDK 7 harness adapter, agent delegation, sandbox transport, and json-render components (#302)
+
+### Bug Fixes
+
+- **Chained action params:** Named `onSuccess` and `onError` actions now receive their configured `params` across core and all renderer bridges (#307)
+- **Consistent optional visibility:** Element `visible` fields now remain optional across Zod 4 versions, while prompts explicitly require `children` arrays for every element (#299)
+- **Spec validation and autofix:** Dangling child references are pruned, malformed visibility conditions are reported, and repeated items can be filtered safely (#300)
+
+### Improvements
+
+- **Release toolchain hardening:** The workspace now requires Node.js 24 and pnpm 11, enforces package engine checks, and applies a minimum package release age (#293)
+
+### Breaking Changes
+
+- Custom renderer bridges that implement the core `executeAction` callback must now accept an `ActionBinding` instead of a bare action name. This exposes chained action params to custom integrations at compile time (#307)
+
+### Contributors
+
+- @ctate
+- @Railly
+- @tmchow
+- @wotnak
+<!-- release:end -->
+
+## 0.19.0
+
 ### New Features
 
 - **Custom directives API** — `@json-render/core` now supports custom directives via `defineDirective`, letting you declare new JSON shapes (like `$format`, `$math`) that resolve to computed values at render time. Directives compose naturally — nest `$format` over `$math` over `$state` and they resolve inside-out. All four renderers (React, Vue, Svelte, Solid) have built-in directive resolution (#279)
@@ -15,7 +46,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.18.0
 

--- a/apps/web/app/(main)/docs/changelog/page.mdx
+++ b/apps/web/app/(main)/docs/changelog/page.mdx
@@ -5,6 +5,72 @@ export const metadata = pageMetadata("docs/changelog")
 
 Notable changes and updates to json-render.
 
+## v0.20.0
+
+August 15, 2026
+
+### New: Named Slots for React
+
+React components can now declare named slots such as `header` and `footer`, while `children` remains the default slot. Named slots are preserved through validation, streaming, nested conversion, code export, playground views, and Devtools navigation.
+
+This work builds on the original named slots contribution by @wotnak.
+
+```tsx
+const catalog = defineCatalog(schema, {
+  components: {
+    Layout: {
+      props: z.object({}),
+      slots: ["default", "header", "footer"],
+    },
+  },
+});
+
+const { registry } = defineRegistry(catalog, {
+  components: {
+    Layout: ({ children, slots }) => (
+      <section>
+        <header>{slots?.header}</header>
+        <main>{children}</main>
+        <footer>{slots?.footer}</footer>
+      </section>
+    ),
+  },
+});
+```
+
+### New: Nested Repeats
+
+`repeat.statePath` now accepts item-relative paths such as `{ "$item": "employees" }`. Nested data can be rendered across React, React Native, React Email, React PDF, Image, Ink, Solid, Svelte, and Vue.
+
+This work builds on the original nested repeats contribution by @tmchow.
+
+```json
+{
+  "type": "Table",
+  "repeat": { "statePath": { "$item": "employees" }, "key": "id" },
+  "children": ["employee-row"],
+  "props": {}
+}
+```
+
+### New: Harness Chat Example
+
+Added a complete Next.js example using the AI SDK 7 harness adapter, agent delegation, sandbox transport, and json-render components.
+
+### Fixed: Chained Action Params
+
+Named `onSuccess` and `onError` actions now receive their configured `params` across core and all renderer bridges. Custom renderer bridges must now accept an `ActionBinding` in the core `executeAction` callback instead of a bare action name.
+
+### Improved: Spec Validation and Compatibility
+
+Element visibility remains optional across Zod 4 versions. Autofix now prunes dangling child references, validation reports malformed visibility conditions, and repeated items can be filtered safely.
+
+### Improved: Release Toolchain
+
+The workspace now requires Node.js 24 and pnpm 11, enforces package engine checks, and applies a minimum package release age.
+
+---
+
 ## v0.19.0
 
 May 6, 2026

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/codegen",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Utilities for generating code from json-render UI trees",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/core",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "JSON becomes real things. Define your catalog, register your components, let AI generate.",
   "keywords": [

--- a/packages/devtools-react/package.json
+++ b/packages/devtools-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-react",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "React adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools-solid/package.json
+++ b/packages/devtools-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-solid",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "SolidJS adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools-svelte/package.json
+++ b/packages/devtools-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-svelte",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Svelte adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools-vue/package.json
+++ b/packages/devtools-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools-vue",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Vue adapter for @json-render/devtools. Drop-in <JsonRenderDevtools /> component.",
   "keywords": [

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/devtools",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Framework-agnostic devtools core for json-render: event store, panel UI, picker, stream taps.",
   "keywords": [

--- a/packages/directives/package.json
+++ b/packages/directives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/directives",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Pre-built directives for @json-render/core — $format, $math, $concat, $count, $truncate, $pluralize, $join, and $t (i18n).",
   "keywords": [

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/image",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Image renderer for @json-render/core. JSON becomes SVG and PNG images via Satori.",
   "keywords": [

--- a/packages/ink/package.json
+++ b/packages/ink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/ink",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Ink terminal renderer for @json-render/core. JSON becomes terminal UIs.",
   "keywords": [

--- a/packages/jotai/package.json
+++ b/packages/jotai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/jotai",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Jotai adapter for json-render StateStore",
   "keywords": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/mcp",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "MCP Apps integration for @json-render/core. Serve json-render UIs as interactive MCP Apps in Claude, ChatGPT, Cursor, and VS Code.",
   "keywords": [

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/next",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Next.js renderer for @json-render/core. JSON becomes full Next.js applications with routes, layouts, metadata, and SSR.",
   "keywords": [

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-email",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "React Email renderer for @json-render/core. JSON becomes HTML emails.",
   "keywords": [

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-native",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "React Native renderer for @json-render/core. JSON becomes React Native components.",
   "keywords": [

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-pdf",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "React PDF renderer for @json-render/core. JSON becomes PDF documents.",
   "keywords": [

--- a/packages/react-three-fiber/package.json
+++ b/packages/react-three-fiber/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react-three-fiber",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "React Three Fiber renderer for @json-render/core. JSON becomes 3D scenes.",
   "keywords": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/react",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "React renderer for @json-render/core. JSON becomes React components.",
   "keywords": [

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/redux",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Redux adapter for json-render StateStore",
   "keywords": [

--- a/packages/remotion/package.json
+++ b/packages/remotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/remotion",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Remotion renderer for @json-render/core. JSON becomes video compositions.",
   "keywords": [

--- a/packages/shadcn-svelte/package.json
+++ b/packages/shadcn-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/shadcn-svelte",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "shadcn-svelte component library for @json-render/svelte. JSON becomes beautiful Tailwind-styled Svelte components.",
   "keywords": [

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/shadcn",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "shadcn/ui component library for @json-render/core. JSON becomes beautiful Tailwind-styled React components.",
   "keywords": [

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/solid",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "SolidJS renderer for @json-render/core. JSON becomes Solid components.",
   "keywords": [

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/svelte",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Svelte 5 renderer for @json-render/core. JSON becomes Svelte components.",
   "keywords": [

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/vue",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Vue renderer for @json-render/core. JSON becomes Vue components.",
   "keywords": [

--- a/packages/xstate/package.json
+++ b/packages/xstate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/xstate",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "XState Store adapter for json-render StateStore",
   "keywords": [

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/yaml",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "YAML wire format for @json-render/core. Progressive rendering and surgical edits via streaming YAML.",
   "keywords": [

--- a/packages/zustand/package.json
+++ b/packages/zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@json-render/zustand",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "Apache-2.0",
   "description": "Zustand adapter for json-render StateStore",
   "keywords": [


### PR DESCRIPTION
## Summary

- bump all 28 public `@json-render/*` packages from `0.19.0` to `0.20.0`
- add release notes for #293, #299, #300, #302, #307, #319, and #320
- document the `executeAction(ActionBinding)` breaking change
- credit @ctate, @Railly, @tmchow, and @wotnak
- update the web changelog

## Verification

- `pnpm type-check` (59/59)
- `pnpm build` (52/52)
- `pnpm run version:check`
- `git diff --check`
- release-note extraction using the workflow's `awk` command
