### PR TITLE
feat(vue): support named slots

### DIFF
--- a/apps/web/app/(main)/docs/api/vue/page.mdx
+++ b/apps/web/app/(main)/docs/api/vue/page.mdx
@@ -95,7 +95,7 @@ store.set("/count", 1);
 
 ## defineRegistry
 
-Create a type-safe component registry from a catalog. Components receive `props`, `children`, `emit`, `on`, and `loading` with catalog-inferred types.
+Create a type-safe component registry from a catalog. Components receive `props`, `children`, `slots`, `emit`, `on`, and `loading` with catalog-inferred types.
 
 When the catalog declares actions, the `actions` field is required. When the catalog has no actions (e.g. `actions: {}`), the field is optional. When passing stubs, any `async () => {}` is sufficient.
 
@@ -105,8 +105,12 @@ import { defineRegistry } from "@json-render/vue";
 
 const { registry } = defineRegistry(catalog, {
   components: {
-    Card: ({ props, children }) =>
-      h("div", { class: "card" }, [h("h3", null, props.title), children]),
+    Layout: ({ slots }) =>
+      h("div", { class: "layout" }, [
+        h("header", null, slots.header?.()),
+        h("main", null, slots.default?.()),
+        h("footer", null, slots.footer?.()),
+      ]),
     Button: ({ props, emit }) =>
       h("button", { onClick: () => emit("press") }, props.label),
   },
@@ -136,11 +140,12 @@ const { registry } = defineRegistry(catalog, {
 ### Component Props (via defineRegistry)
 
 ```typescript
-import type { VNode } from "vue";
+import type { Slots, VNode } from "vue";
 
 interface ComponentContext<P> {
   props: P;                          // Typed props from catalog
   children?: VNode | VNode[];        // Rendered children (for container components)
+  slots: Slots;                      // Vue-native slot functions
   emit: (event: string) => void;     // Emit a named event (always defined)
   on: (event: string) => EventHandle; // Get event handle with metadata
   loading?: boolean;
@@ -153,6 +158,22 @@ interface EventHandle {
   bound: boolean;                // Whether any handler is bound
 }
 ```
+
+Use `children` for the default slot. For other slots declared by the catalog, add a top-level `slots` map to the spec element:
+
+```json
+{
+  "type": "Layout",
+  "props": {},
+  "children": ["main-content"],
+  "slots": {
+    "header": ["page-heading"],
+    "footer": ["page-actions"]
+  }
+}
+```
+
+The component renders these regions with Vue's native slot functions: `slots.header?.()`, `slots.footer?.()`, and so on. `slots.default?.()` renders the spec's `children`; `children` is a convenience alias for that rendered result. In the JSON spec, keep default content in `children` rather than adding a `default` entry to `slots`.
 
 Use `emit("press")` for simple event firing. Use `on("click")` when you need metadata like `shouldPreventDefault`:
 

--- a/apps/web/app/(main)/docs/specs/page.mdx
+++ b/apps/web/app/(main)/docs/specs/page.mdx
@@ -206,7 +206,7 @@ Each element in the map has a consistent shape:
 - `type` — Component type from your catalog
 - `props` — Component properties
 - `children` — Array of child element keys
-- `slots`: Optional map of named slots to child element keys. Use `children` for the default slot. Named slot rendering is currently supported by `@json-render/react`.
+- `slots`: Optional map of named slots to child element keys. Use `children` for the default slot. Named slot rendering is supported by `@json-render/react` and `@json-render/vue`.
 
 ### Dynamic Data
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -26,6 +26,7 @@ export const catalog = defineCatalog(schema, {
         title: z.string(),
         description: z.string().nullable(),
       }),
+      slots: ["default", "header", "footer"],
       description: "A card container",
     },
     Button: {
@@ -53,7 +54,7 @@ export const catalog = defineCatalog(schema, {
 
 ### 2. Define Component Implementations
 
-Components are written using Vue's `h()` render function. `children` is a `VNode | VNode[]` — pass it directly to your container element.
+Components are written using Vue's `h()` render function. The `slots` context uses Vue's native slot functions, so render a region with `slots.header?.()`. For convenience and React parity, `children` contains the already-rendered result of `slots.default?.()`.
 
 `defineRegistry` conditionally requires the `actions` field only when the catalog declares actions. Catalogs with `actions: {}` can omit it entirely.
 
@@ -64,11 +65,12 @@ import { catalog } from "./catalog";
 
 export const { registry } = defineRegistry(catalog, {
   components: {
-    Card: ({ props, children }) =>
+    Card: ({ props, slots }) =>
       h("div", { class: "card" }, [
-        h("h3", null, props.title),
+        h("header", null, slots.header?.() ?? h("h3", null, props.title)),
         props.description ? h("p", null, props.description) : null,
-        children,
+        slots.default?.(),
+        h("footer", null, slots.footer?.()),
       ]),
     Button: ({ props, emit }) =>
       h("button", { onClick: () => emit("press") }, props.label),
@@ -131,6 +133,7 @@ interface UIElement {
   type: string;                          // Component name from catalog
   props: Record<string, unknown>;        // Component props
   children?: string[];                   // Keys of child elements
+  slots?: Record<string, string[]>;      // Named slots mapped to child keys
   visible?: VisibilityCondition;         // Visibility condition
 }
 ```
@@ -162,6 +165,35 @@ Example spec:
   }
 }
 ```
+
+### Named Slots
+
+Use `children` for the default slot and the element's top-level `slots` object for other slot names declared by the catalog:
+
+```typescript
+Layout: ({ children, slots }) =>
+  h("div", null, [
+    h("header", null, slots.header?.()),
+    h("main", null, children),
+    h("footer", null, slots.footer?.()),
+  ]),
+```
+
+The corresponding spec maps element keys to each region:
+
+```json
+{
+  "type": "Layout",
+  "props": {},
+  "children": ["main-content"],
+  "slots": {
+    "header": ["page-heading"],
+    "footer": ["page-actions"]
+  }
+}
+```
+
+Registry components receive Vue-native slot functions and render them with `slots.header?.()`, `slots.footer?.()`, and so on. `slots.default?.()` renders the spec's `children`; `children` is an alias for that rendered result. In the JSON spec, keep default content in `children` rather than adding a `default` entry to `slots`.
 
 ## Providers
 
@@ -366,11 +398,12 @@ The `setState`, `pushState`, `removeState`, and `validateForm` actions are built
 When using `defineRegistry`, components receive these props via their render function:
 
 ```typescript
-import type { VNode } from "vue";
+import type { Slots, VNode } from "vue";
 
 interface ComponentContext<P> {
   props: P;                          // Typed props from the catalog (expressions resolved)
   children?: VNode | VNode[];        // Rendered children (for container components)
+  slots: Slots;                      // Vue-native slot functions
   emit: (event: string) => void;     // Emit a named event (always defined)
   on: (event: string) => EventHandle; // Get event handle with metadata
   loading?: boolean;                 // Whether the parent is loading

--- a/packages/vue/src/catalog-types.ts
+++ b/packages/vue/src/catalog-types.ts
@@ -1,4 +1,4 @@
-import type { VNode } from "vue";
+import type { Slots, VNode } from "vue";
 import type {
   Catalog,
   InferCatalogComponents,
@@ -59,6 +59,8 @@ export interface BaseComponentProps<P = Record<string, unknown>> {
   props: P;
   /** Rendered children (from the default slot) */
   children?: VNode | VNode[];
+  /** Vue-native slot functions, including the default slot */
+  slots: Slots;
   /** Simple event emitter (shorthand). Fires the event and returns void. */
   emit: (event: string) => void;
   /** Get an event handle with metadata. Use when you need shouldPreventDefault or bound checks. */

--- a/packages/vue/src/hooks.test.ts
+++ b/packages/vue/src/hooks.test.ts
@@ -128,6 +128,31 @@ describe("buildSpecFromParts", () => {
     ];
     expect(buildSpecFromParts(parts)).toBeNull();
   });
+
+  it("preserves named slots in nested spec parts", () => {
+    const spec = buildSpecFromParts([
+      {
+        type: SPEC_DATA_PART_TYPE,
+        data: {
+          type: "nested",
+          spec: {
+            type: "Layout",
+            props: {},
+            slots: {
+              header: [
+                { type: "Heading", props: { text: "Header" }, children: [] },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(spec).not.toBeNull();
+    const root = spec!.elements[spec!.root]!;
+    expect(root.slots?.header).toHaveLength(1);
+    expect(spec!.elements[root.slots!.header![0]!]!.type).toBe("Heading");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/vue/src/renderer.test.ts
+++ b/packages/vue/src/renderer.test.ts
@@ -1,12 +1,18 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { defineComponent, h, type Component } from "vue";
 import { mount } from "@vue/test-utils";
-import type { Spec } from "@json-render/core";
+import { defineCatalog, type Spec } from "@json-render/core";
+import { z } from "zod";
 import { StateProvider } from "./composables/state";
 import { VisibilityProvider } from "./composables/visibility";
 import { ActionProvider } from "./composables/actions";
 import { ValidationProvider } from "./composables/validation";
 import { Renderer, defineRegistry, type ComponentRegistry } from "./renderer";
+import { schema } from "./schema";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // ---------------------------------------------------------------------------
 // Minimal test catalog and registry
@@ -68,6 +74,23 @@ function mountRenderer(
   });
 }
 
+function layoutSpec(slots: Record<string, string[]>): Spec {
+  return {
+    root: "layout",
+    elements: {
+      layout: {
+        type: "Layout",
+        props: {},
+        children: ["main"],
+        slots,
+      },
+      main: { type: "Text", props: { text: "Main" } },
+      header: { type: "Text", props: { text: "Header" } },
+      other: { type: "Text", props: { text: "Other" } },
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // defineRegistry tests
 // ---------------------------------------------------------------------------
@@ -111,6 +134,122 @@ describe("defineRegistry", () => {
     expect(wrapper.find("[data-type='button']").exists()).toBe(true);
   });
 
+  it("renders named slots as Vue slot functions through defineRegistry", () => {
+    const namedSlotsCatalog = defineCatalog(schema, {
+      components: {
+        Layout: {
+          props: z.object({}),
+          slots: ["default", "header", "footer"],
+        },
+        Text: {
+          props: z.object({ text: z.string() }),
+          slots: [],
+        },
+      },
+      actions: {},
+    });
+    const { registry: namedSlotsRegistry } = defineRegistry(namedSlotsCatalog, {
+      components: {
+        Layout: ({ slots }) =>
+          h("section", null, [
+            h("header", { "data-testid": "header-slot" }, slots.header?.()),
+            h("main", { "data-testid": "default-slot" }, slots.default?.()),
+            h("footer", { "data-testid": "footer-slot" }, slots.footer?.()),
+          ]),
+        Text: ({ props }) => h("span", null, props.text),
+      },
+    });
+    const spec: Spec = {
+      root: "layout",
+      elements: {
+        layout: {
+          type: "Layout",
+          props: {},
+          children: ["main"],
+          slots: {
+            header: ["header"],
+            footer: ["footer"],
+          },
+        },
+        header: { type: "Text", props: { text: "Header" } },
+        main: { type: "Text", props: { text: "Main" } },
+        footer: { type: "Text", props: { text: "Footer" } },
+      },
+    };
+
+    const wrapper = mountRenderer(spec, namedSlotsRegistry);
+
+    expect(wrapper.find('[data-testid="header-slot"]').text()).toBe("Header");
+    expect(wrapper.find('[data-testid="default-slot"]').text()).toBe("Main");
+    expect(wrapper.find('[data-testid="footer-slot"]').text()).toBe("Footer");
+  });
+
+  it("advertises named slots in the Vue catalog prompt without default", () => {
+    const namedSlotsCatalog = defineCatalog(schema, {
+      components: {
+        Layout: { props: z.object({}), slots: ["default", "header"] },
+      },
+      actions: {},
+    });
+
+    const prompt = namedSlotsCatalog.prompt();
+
+    expect(prompt).toContain("slots: header");
+    expect(prompt).not.toContain("slots: default");
+  });
+
+  it("warns and ignores slots.default while preserving children", () => {
+    const namedSlotsCatalog = defineCatalog(schema, {
+      components: {
+        Layout: { props: z.object({}), slots: ["default"] },
+        Text: { props: z.object({ text: z.string() }), slots: [] },
+      },
+      actions: {},
+    });
+    const { registry: namedSlotsRegistry } = defineRegistry(namedSlotsCatalog, {
+      components: {
+        Layout: ({ children }) => h("main", null, children),
+        Text: ({ props }) => h("span", null, props.text),
+      },
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const wrapper = mountRenderer(
+      layoutSpec({ default: ["other"] }),
+      namedSlotsRegistry,
+    );
+
+    expect(wrapper.text()).toBe("Main");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("slots.default"));
+  });
+
+  it("warns but renders an undeclared named slot", () => {
+    const namedSlotsCatalog = defineCatalog(schema, {
+      components: {
+        Layout: { props: z.object({}), slots: ["default"] },
+        Text: { props: z.object({ text: z.string() }), slots: [] },
+      },
+      actions: {},
+    });
+    const { registry: namedSlotsRegistry } = defineRegistry(namedSlotsCatalog, {
+      components: {
+        Layout: ({ slots }) => h("aside", null, slots.sidebar?.()),
+        Text: ({ props }) => h("span", null, props.text),
+      },
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const wrapper = mountRenderer(
+      layoutSpec({ sidebar: ["other"] }),
+      namedSlotsRegistry,
+    );
+
+    expect(wrapper.text()).toBe("Other");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown slot "sidebar"'),
+    );
+  });
+
   it("emit('press') fires the corresponding on.press action", async () => {
     const handler = vi.fn().mockResolvedValue(undefined);
     const spec: Spec = {
@@ -134,6 +273,99 @@ describe("defineRegistry", () => {
 // ---------------------------------------------------------------------------
 
 describe("Renderer", () => {
+  it("delivers raw registry named slots lazily", () => {
+    let footerCalls = 0;
+    const Layout = defineComponent({
+      setup(_, { slots }) {
+        return () =>
+          h("section", null, [
+            h("header", null, slots.header?.()),
+            h("main", null, slots.default?.()),
+            slots.footer ? h("i", null, "has-footer") : null,
+          ]);
+      },
+    });
+    const Text = defineComponent({
+      props: { element: { type: Object, required: true } },
+      setup(props) {
+        return () => h("span", null, (props.element as any).props.text);
+      },
+    });
+    const Footer = defineComponent({
+      setup() {
+        footerCalls += 1;
+        return () => h("span", null, "Footer");
+      },
+    });
+    const spec = layoutSpec({ header: ["header"], footer: ["footer"] });
+    spec.elements.footer = { type: "Footer", props: {} };
+
+    const wrapper = mountRenderer(spec, { Layout, Text, Footer });
+
+    expect(wrapper.text()).toContain("Header");
+    expect(wrapper.text()).toContain("Main");
+    expect(wrapper.text()).toContain("has-footer");
+    expect(wrapper.text()).not.toContain("Footer");
+    expect(footerCalls).toBe(0);
+  });
+
+  it("suppresses missing named slot warnings while loading", () => {
+    const Layout = defineComponent({
+      setup(_, { slots }) {
+        return () => h("header", null, slots.header?.());
+      },
+    });
+    const spec = layoutSpec({ header: ["missing"] });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const loadingWrapper = mountRenderer(spec, { Layout }, { loading: true });
+    expect(warn).not.toHaveBeenCalled();
+    loadingWrapper.unmount();
+
+    mountRenderer(spec, { Layout }, { loading: false });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('in slot "header"'),
+    );
+  });
+
+  it("renders owner named slots once outside the owner repeat scope", () => {
+    const Layout = defineComponent({
+      setup(_, { slots }) {
+        return () => h("section", null, [slots.header?.(), slots.default?.()]);
+      },
+    });
+    const Text = defineComponent({
+      props: { element: { type: Object, required: true } },
+      setup(props) {
+        return () => h("span", null, (props.element as any).props.text);
+      },
+    });
+    const spec: Spec = {
+      root: "layout",
+      elements: {
+        layout: {
+          type: "Layout",
+          props: {},
+          repeat: { statePath: "/items" },
+          children: ["row"],
+          slots: { header: ["header"] },
+        },
+        row: { type: "Text", props: { text: { $item: "name" } } },
+        header: { type: "Text", props: { text: "Header" } },
+      },
+    };
+
+    const wrapper = mountRenderer(
+      spec,
+      { Layout, Text },
+      {},
+      {},
+      { items: [{ name: "A" }, { name: "B" }] },
+    );
+
+    expect(wrapper.text()).toBe("HeaderAB");
+  });
+
   it("renders a single-element spec", () => {
     const spec: Spec = {
       root: "btn1",

--- a/packages/vue/src/renderer.ts
+++ b/packages/vue/src/renderer.ts
@@ -11,6 +11,7 @@ import {
   type Component,
   type ComputedRef,
   type PropType,
+  type Slots,
   type VNode,
 } from "vue";
 import type {
@@ -82,6 +83,11 @@ export interface ComponentRenderProps<P = Record<string, unknown>> {
  * Registry of component renderers (Vue component definitions)
  */
 export type ComponentRegistry = Record<string, Component>;
+
+const registryMetadata = new WeakMap<
+  ComponentRegistry,
+  Record<string, { slots?: string[] }>
+>();
 
 /**
  * Props for the Renderer component
@@ -395,6 +401,51 @@ const ElementRenderer = defineComponent({
         return null;
       }
 
+      const metadata = registryMetadata.get(props.registry)?.[
+        resolvedElement.type
+      ];
+      if (resolvedElement.slots && metadata?.slots) {
+        const availableSlots = new Set(metadata.slots);
+        for (const slotName of Object.keys(resolvedElement.slots)) {
+          if (slotName === "default") {
+            console.warn(
+              `[json-render] Component "${resolvedElement.type}" uses slots.default. Use "children" for default slot content.`,
+            );
+          } else if (!availableSlots.has(slotName)) {
+            console.warn(
+              `[json-render] Unknown slot "${slotName}" on component "${resolvedElement.type}". Available slots: ${metadata.slots.join(", ")}`,
+            );
+          }
+        }
+      }
+
+      const renderChildKeys = (childKeys: string[], slotName?: string) =>
+        childKeys
+          .map((childKey) => {
+            const childElement = props.spec.elements[childKey];
+            if (!childElement) {
+              if (!props.loading) {
+                const location = slotName
+                  ? `in slot "${slotName}" of "${resolvedElement.type}"`
+                  : `as child of "${resolvedElement.type}"`;
+                console.warn(
+                  `[json-render] Missing element "${childKey}" referenced ${location}. This element will not render.`,
+                );
+              }
+              return null;
+            }
+            return h(ElementRenderer, {
+              key: childKey,
+              element: childElement,
+              elementKey: childKey,
+              spec: props.spec,
+              registry: props.registry,
+              loading: props.loading,
+              fallback: props.fallback,
+            });
+          })
+          .filter((node): node is VNode => node !== null);
+
       // Render children
       const childrenVNodes: VNode | VNode[] | undefined = resolvedElement.repeat
         ? h(RepeatChildren, {
@@ -404,28 +455,20 @@ const ElementRenderer = defineComponent({
             loading: props.loading,
             fallback: props.fallback,
           })
-        : (resolvedElement.children
-            ?.map((childKey) => {
-              const childElement = props.spec.elements[childKey];
-              if (!childElement) {
-                if (!props.loading) {
-                  console.warn(
-                    `[json-render] Missing element "${childKey}" referenced as child of "${resolvedElement.type}". This element will not render.`,
-                  );
-                }
-                return null;
-              }
-              return h(ElementRenderer, {
-                key: childKey,
-                element: childElement,
-                elementKey: childKey,
-                spec: props.spec,
-                registry: props.registry,
-                loading: props.loading,
-                fallback: props.fallback,
-              });
-            })
-            .filter((n): n is VNode => n !== null) ?? undefined);
+        : resolvedElement.children
+          ? renderChildKeys(resolvedElement.children)
+          : undefined;
+
+      const namedSlots = resolvedElement.slots
+        ? Object.fromEntries(
+            Object.entries(resolvedElement.slots)
+              .filter(([slotName]) => slotName !== "default")
+              .map(([slotName, childKeys]) => [
+                slotName,
+                () => renderChildKeys(childKeys, slotName),
+              ]),
+          )
+        : {};
 
       const componentVNode = h(
         Component,
@@ -436,7 +479,7 @@ const ElementRenderer = defineComponent({
           bindings: elementBindings,
           loading: props.loading,
         },
-        { default: () => childrenVNodes },
+        { default: () => childrenVNodes, ...namedSlots },
       );
 
       // When devtools is mounted, wrap each element in a transparent span so
@@ -783,6 +826,7 @@ type DefineRegistryOptions<C extends Catalog> = {
 type DefineRegistryComponentFn = (ctx: {
   props: unknown;
   children?: VNode | VNode[];
+  slots: Slots;
   emit: (event: string) => void;
   on: (event: string) => EventHandle;
   bindings?: Record<string, string>;
@@ -815,7 +859,7 @@ type DefineRegistryActionFn = (
  * ```
  */
 export function defineRegistry<C extends Catalog>(
-  _catalog: C,
+  catalog: C,
   options: DefineRegistryOptions<C>,
 ): DefineRegistryResult {
   const registry: ComponentRegistry = {};
@@ -851,6 +895,7 @@ export function defineRegistry<C extends Catalog>(
             (componentFn as DefineRegistryComponentFn)({
               props: registryProps.element.props,
               children: slots.default?.(),
+              slots,
               emit: registryProps.emit,
               on: registryProps.on,
               bindings: registryProps.bindings,
@@ -859,6 +904,14 @@ export function defineRegistry<C extends Catalog>(
         },
       });
     }
+  }
+  const catalogComponents = (
+    catalog as {
+      data?: { components?: Record<string, { slots?: string[] }> };
+    }
+  ).data?.components;
+  if (catalogComponents) {
+    registryMetadata.set(registry, catalogComponents);
   }
 
   const actionMap = options.actions
@@ -957,6 +1010,12 @@ export function createRenderer<
 ): Component {
   const registry: ComponentRegistry =
     components as unknown as ComponentRegistry;
+  const catalogComponents = (
+    catalog.data as { components?: Record<string, { slots?: string[] }> }
+  ).components;
+  if (catalogComponents) {
+    registryMetadata.set(registry, catalogComponents);
+  }
 
   return defineComponent({
     name: "CatalogRenderer",

--- a/packages/vue/src/schema.ts
+++ b/packages/vue/src/schema.ts
@@ -22,6 +22,8 @@ export const schema = defineSchema(
           props: s.propsOf("catalog.components"),
           /** Child element keys (flat reference) */
           children: s.array(s.string()),
+          /** Named slots mapped to child element keys */
+          slots: { ...s.record(s.array(s.string())), ...s.optional() },
           /** Visibility condition */
           visible: { ...s.any(), ...s.optional() },
           /** Repeat children from a state array */
@@ -80,6 +82,7 @@ export const schema = defineSchema(
       "CRITICAL INTEGRITY CHECK: Before outputting ANY element that references children, you MUST have already output (or will output) each child as its own element. If an element has children: ['a', 'b'], then elements 'a' and 'b' MUST exist. A missing child element causes that entire branch of the UI to be invisible.",
       "SELF-CHECK: After generating all elements, mentally walk the tree from root. Every key in every children array must resolve to a defined element. If you find a gap, output the missing element immediately.",
       'REQUIRED FIELDS: Every element MUST include a "children" array. Leaf elements (text, badges, inputs, images) use an empty array: "children": []. Omitting "children" fails validation.',
+      'NAMED SLOTS: Use "children" for the default slot. For other slots declared by the component, use a top-level "slots" object that maps each slot name to child element keys, for example {"slots":{"header":["heading"],"footer":["actions"]}}. Never use "slots.default". Every referenced key must exist.',
 
       // Field placement
       'CRITICAL: The "visible" field goes on the ELEMENT object, NOT inside "props". Correct: {"type":"<ComponentName>","props":{},"visible":{"$state":"/tab","eq":"home"},"children":[...]}.',

--- a/skills/vue/SKILL.md
+++ b/skills/vue/SKILL.md
@@ -28,7 +28,13 @@ export const catalog = defineCatalog(schema, {
   components: {
     Card: {
       props: z.object({ title: z.string(), description: z.string().nullable() }),
+      slots: ["default"],
       description: "A card container",
+    },
+    Layout: {
+      props: z.object({}),
+      slots: ["default", "header", "footer"],
+      description: "Layout with named content regions",
     },
     Button: {
       props: z.object({ label: z.string(), action: z.string() }),
@@ -54,11 +60,35 @@ export const { registry } = defineRegistry(catalog, {
         props.description ? h("p", null, props.description) : null,
         children,
       ]),
+    Layout: ({ slots }) =>
+      h("div", null, [
+        h("header", null, slots.header?.()),
+        h("main", null, slots.default?.()),
+        h("footer", null, slots.footer?.()),
+      ]),
     Button: ({ props, emit }) =>
       h("button", { onClick: () => emit("press") }, props.label),
   },
 });
 ```
+
+## Named Slots
+
+Use `children` for the `"default"` slot. Use the element's top-level `slots` object for other slot names declared by the catalog:
+
+```json
+{
+  "type": "Layout",
+  "props": {},
+  "children": ["main"],
+  "slots": {
+    "header": ["heading"],
+    "footer": ["actions"]
+  }
+}
+```
+
+Registry components receive Vue-native slot functions. Render them with `slots.header?.()`, `slots.footer?.()`, and so on. `slots.default?.()` renders the spec's `children`; the `children` context field is a convenience alias for that rendered result. In the JSON spec, keep default content in `children` rather than adding a `default` entry to `slots`.
 
 ### Render Specs
 


### PR DESCRIPTION
## Summary

Recreates the Vue named slots implementation from #322 on top of current `main`, with `@wotnak` preserved as co-author.

- exposes Vue-native lazy slot functions through `defineRegistry`
- renders `children` as the default slot and `slots` as named slots
- supports raw Vue registries through the same low-level renderer path
- adds catalog-backed slot warnings and Vue schema/prompt support
- updates Vue docs and skill guidance
- adds regression coverage for raw registries, lazy non-consumption, `slots.default`, undeclared slots, loading warnings, repeat scope, nested conversion, and prompt output

Supersedes #322 after preserving its implementation and authorship.

## Verification

- focused Vue renderer/hooks: 36/36
- full test suite: 1,069/1,069
- type-check: 59/59 tasks
- lint: 14/14 tasks
- force-red: removing named-slot delivery fails five focused tests
- Solution Gate: Amend and recreate with credit
- Review Gate: pass on `a34d63b`

Co-authored implementation credit: @wotnak
