### PR TITLE
fix(react): stabilize streaming renders

### DIFF
--- a/packages/react/src/contexts/validation.tsx
+++ b/packages/react/src/contexts/validation.tsx
@@ -50,6 +50,7 @@ export interface ValidationContextValue {
 }
 
 const ValidationContext = createContext<ValidationContextValue | null>(null);
+const EMPTY_VALIDATION_FUNCTIONS: Record<string, ValidationFunction> = {};
 
 /**
  * Props for ValidationProvider
@@ -127,7 +128,7 @@ function validationConfigEqual(
  * Provider for validation
  */
 export function ValidationProvider({
-  customFunctions = {},
+  customFunctions = EMPTY_VALIDATION_FUNCTIONS,
   children,
 }: ValidationProviderProps) {
   const { state, getSnapshot } = useStateStore();

--- a/packages/react/src/json325-contract-probe.test.tsx
+++ b/packages/react/src/json325-contract-probe.test.tsx
@@ -1,0 +1,361 @@
+import { act, render } from "@testing-library/react";
+import type { Spec } from "@json-render/core";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useStateStore } from "./contexts/state";
+import { JSONUIProvider, Renderer, type ComponentRegistry } from "./renderer";
+
+function renderValue(value: unknown) {
+  const registry: ComponentRegistry = {
+    Value: ({ element }) => <span>{String(element.props.value)}</span>,
+  };
+  const spec: Spec = {
+    root: "value",
+    elements: { value: { type: "Value", props: { value } } },
+  };
+  return {
+    registry,
+    spec,
+    view: render(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    ),
+  };
+}
+
+describe("JSON Render PR #325 contract probes", () => {
+  it("preserves nested resolved prop identity across unrelated state writes", () => {
+    let effects = 0;
+    function Value({
+      element,
+    }: React.ComponentProps<ComponentRegistry[string]>) {
+      const { set } = useStateStore();
+      React.useEffect(() => {
+        effects += 1;
+        if (effects < 3) set("/unrelated", effects);
+      }, [element.props.options, set]);
+      return null;
+    }
+    const registry: ComponentRegistry = { Value };
+    const spec: Spec = {
+      root: "value",
+      elements: {
+        value: {
+          type: "Value",
+          props: { options: { layout: { gap: 8 } } },
+        },
+      },
+    };
+
+    render(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    );
+
+    expect(effects).toBe(1);
+  });
+
+  it("shares unchanged resolved subtrees when a sibling changes", () => {
+    const observed: Array<Record<string, unknown>> = [];
+    const registry: ComponentRegistry = {
+      Value: ({ element }) => {
+        observed.push(element.props);
+        return null;
+      },
+    };
+    const first: Spec = {
+      root: "value",
+      state: { revision: 1 },
+      elements: {
+        value: {
+          type: "Value",
+          props: {
+            options: { layout: { gap: 8 }, columns: [1, 2] },
+            revision: { $state: "/revision" },
+          },
+        },
+      },
+    };
+    let setRevision: ((value: number) => void) | undefined;
+    function Controls() {
+      const { set } = useStateStore();
+      setRevision = (value) => set("/revision", value);
+      return null;
+    }
+
+    render(
+      <JSONUIProvider registry={registry} initialState={first.state}>
+        <Controls />
+        <Renderer spec={first} registry={registry} />
+      </JSONUIProvider>,
+    );
+    act(() => setRevision?.(2));
+
+    expect(observed).toHaveLength(2);
+    expect(observed[1]).not.toBe(observed[0]);
+    expect(observed[1]?.options).toBe(observed[0]?.options);
+    expect((observed[1]?.options as { layout: unknown }).layout).toBe(
+      (observed[0]?.options as { layout: unknown }).layout,
+    );
+    expect((observed[1]?.options as { columns: unknown }).columns).toBe(
+      (observed[0]?.options as { columns: unknown }).columns,
+    );
+    expect(observed[1]?.revision).toBe(2);
+  });
+
+  it("does not mutate containers delivered by reference from state", () => {
+    const observed: unknown[] = [];
+    const registry: ComponentRegistry = {
+      Value: ({ element }) => {
+        observed.push(element.props.user);
+        return null;
+      },
+    };
+    const spec: Spec = {
+      root: "value",
+      state: { user: { profile: { name: "a" }, revision: 1 } },
+      elements: {
+        value: { type: "Value", props: { user: { $state: "/user" } } },
+      },
+    };
+    let setUser: ((value: unknown) => void) | undefined;
+    function Controls() {
+      const { set } = useStateStore();
+      setUser = (value) => set("/user", value);
+      return null;
+    }
+
+    render(
+      <JSONUIProvider registry={registry} initialState={spec.state}>
+        <Controls />
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    );
+    const replacementProfile = { name: "a" };
+    const replacement = { profile: replacementProfile, revision: 2 };
+    act(() => setUser?.(replacement));
+
+    expect(replacement.profile).toBe(replacementProfile);
+    expect((observed.at(-1) as { revision: number }).revision).toBe(2);
+
+    const frozen = Object.freeze({
+      profile: Object.freeze({ name: "a" }),
+      revision: 3,
+    });
+    expect(() => act(() => setUser?.(frozen))).not.toThrow();
+    expect((observed.at(-1) as { revision: number }).revision).toBe(3);
+  });
+
+  it("delivers changed resolved object and array subtrees as fresh values", () => {
+    const observed: unknown[] = [];
+    const registry: ComponentRegistry = {
+      Value: ({ element }) => {
+        observed.push(element.props.options);
+        return null;
+      },
+    };
+    const spec: Spec = {
+      root: "value",
+      state: { gap: 8 },
+      elements: {
+        value: {
+          type: "Value",
+          props: {
+            options: {
+              layout: { gap: { $state: "/gap" } },
+              columns: [{ $state: "/gap" }],
+            },
+          },
+        },
+      },
+    };
+    let setGap: ((value: number) => void) | undefined;
+    function Controls() {
+      const { set } = useStateStore();
+      setGap = (value) => set("/gap", value);
+      return null;
+    }
+
+    render(
+      <JSONUIProvider registry={registry} initialState={spec.state}>
+        <Controls />
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    );
+    act(() => setGap?.(12));
+
+    const first = observed[0] as {
+      layout: Record<string, unknown>;
+      columns: unknown[];
+    };
+    const second = observed[1] as typeof first;
+    expect(second).not.toBe(first);
+    expect(second.layout).not.toBe(first.layout);
+    expect(second.columns).not.toBe(first.columns);
+    expect(second.layout.gap).toBe(12);
+    expect(second.columns[0]).toBe(12);
+  });
+
+  it.each([
+    [
+      "nested present undefined to absent",
+      { value: { nested: undefined } },
+      { value: {} },
+    ],
+    [
+      "nested absent to present undefined",
+      { value: {} },
+      { value: { nested: undefined } },
+    ],
+    ["function identity", { value: () => "first" }, { value: () => "second" }],
+    [
+      "symbol identity",
+      { value: Symbol("first") },
+      { value: Symbol("second") },
+    ],
+    ["BigInt value", { value: 1n }, { value: 2n }],
+  ])("distinguishes changed %s", (_label, firstProps, secondProps) => {
+    const display = (value: unknown) => {
+      if (typeof value === "function") return value();
+      if (value && typeof value === "object") {
+        return Object.keys(value).join(",");
+      }
+      return String(value);
+    };
+    const registry: ComponentRegistry = {
+      Value: ({ element }) => (
+        <span>{`${Object.keys(element.props).join(",")}:${display(element.props.value)}`}</span>
+      ),
+    };
+    const initial: Spec = {
+      root: "value",
+      elements: { value: { type: "Value", props: firstProps } },
+    };
+    const view = render(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={initial} registry={registry} />
+      </JSONUIProvider>,
+    );
+    const next: Spec = {
+      root: "value",
+      elements: { value: { type: "Value", props: secondProps } },
+    };
+
+    view.rerender(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={next} registry={registry} />
+      </JSONUIProvider>,
+    );
+
+    expect(view.container.textContent).toBe(
+      `${Object.keys(secondProps).join(",")}:${display(secondProps.value)}`,
+    );
+  });
+
+  it("accepts BigInt prop values without throwing", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderValue(1n)).not.toThrow();
+    error.mockRestore();
+  });
+
+  it("does not invalidate an unchanged nested NaN value", () => {
+    const component = vi.fn(() => null);
+    const registry: ComponentRegistry = { Value: component };
+    const first: Spec = {
+      root: "value",
+      elements: {
+        value: { type: "Value", props: { value: { nested: Number.NaN } } },
+      },
+    };
+    const view = render(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={first} registry={registry} />
+      </JSONUIProvider>,
+    );
+    const second: Spec = {
+      root: "value",
+      elements: {
+        value: { type: "Value", props: { value: { nested: Number.NaN } } },
+      },
+    };
+
+    view.rerender(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={second} registry={registry} />
+      </JSONUIProvider>,
+    );
+
+    expect(component).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates a nested negative zero to zero transition", () => {
+    const component = vi.fn(
+      ({ element }: React.ComponentProps<ComponentRegistry[string]>) => (
+        <span>
+          {Object.is((element.props.value as { nested: number }).nested, -0)
+            ? "negative-zero"
+            : "zero"}
+        </span>
+      ),
+    );
+    const registry: ComponentRegistry = { Value: component };
+    const first: Spec = {
+      root: "value",
+      elements: {
+        value: { type: "Value", props: { value: { nested: -0 } } },
+      },
+    };
+    const view = render(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={first} registry={registry} />
+      </JSONUIProvider>,
+    );
+    const second: Spec = {
+      root: "value",
+      elements: {
+        value: { type: "Value", props: { value: { nested: 0 } } },
+      },
+    };
+
+    view.rerender(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={second} registry={registry} />
+      </JSONUIProvider>,
+    );
+
+    expect(component).toHaveBeenCalledTimes(2);
+    expect(view.container.textContent).toBe("zero");
+  });
+
+  it.each([
+    ["function", () => "stable"],
+    ["symbol", Symbol("stable")],
+    ["BigInt", 1n],
+  ])("does not invalidate an unchanged %s value", (_label, value) => {
+    const component = vi.fn(() => null);
+    const registry: ComponentRegistry = { Value: component };
+    const first: Spec = {
+      root: "value",
+      elements: { value: { type: "Value", props: { value } } },
+    };
+    const view = render(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={first} registry={registry} />
+      </JSONUIProvider>,
+    );
+    const second: Spec = {
+      root: "value",
+      elements: { value: { type: "Value", props: { value } } },
+    };
+
+    view.rerender(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={second} registry={registry} />
+      </JSONUIProvider>,
+    );
+
+    expect(component).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -93,6 +93,7 @@ const registryMetadata = new WeakMap<
   ComponentRegistry,
   Record<string, { slots?: string[] }>
 >();
+const EMPTY_ELEMENT_PROPS: Record<string, unknown> = {};
 
 /**
  * Props for the Renderer component
@@ -293,7 +294,7 @@ function useElementSignatures(spec: Spec | null): Record<string, number> {
 
       const own = JSON.stringify([
         frame.element,
-        Object.keys(frame.element.props),
+        Object.keys(frame.element.props ?? {}),
       ]);
       const childVersions = JSON.stringify(frame.childVersions);
       const prior = previous[frame.key];
@@ -566,7 +567,9 @@ function ReactiveElementRenderer({
   }
 
   // Resolve $bindState/$bindItem expressions → bindings map (prop name → state path)
-  const rawProps = element.props as Record<string, unknown>;
+  const rawProps =
+    (element.props as Record<string, unknown> | undefined) ??
+    EMPTY_ELEMENT_PROPS;
   const elementBindings = stabilizeRecord(
     resolveBindings(rawProps, fullCtx),
     stableBindingsRef,

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -115,6 +115,7 @@ export interface RendererProps {
 
 interface ElementErrorBoundaryProps {
   elementType: string;
+  resetKey: number | undefined;
   children: ReactNode;
 }
 
@@ -141,6 +142,12 @@ class ElementErrorBoundary extends React.Component<
       error,
       info.componentStack,
     );
+  }
+
+  componentDidUpdate(previous: ElementErrorBoundaryProps) {
+    if (this.state.hasError && previous.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false });
+    }
   }
 
   render() {
@@ -186,7 +193,177 @@ interface ElementRendererProps {
   registry: ComponentRegistry;
   loading?: boolean;
   fallback?: ComponentRenderer;
+  signatures: Record<string, number>;
 }
+
+function stabilizeRecord<T extends Record<string, unknown> | undefined>(
+  value: T,
+  ref: React.MutableRefObject<T>,
+): T {
+  const previous = ref.current;
+  if (previous === value) return previous;
+  if (previous && value) {
+    const keys = Object.keys(value);
+    if (
+      keys.length === Object.keys(previous).length &&
+      keys.every(
+        (key) =>
+          Object.prototype.hasOwnProperty.call(previous, key) &&
+          previous[key] === value[key],
+      )
+    ) {
+      return previous;
+    }
+  }
+  ref.current = value;
+  return value;
+}
+
+interface ElementSignatureEntry {
+  own: string;
+  children: string;
+  version: number;
+}
+
+interface ElementSignatureFrame {
+  key: string;
+  element: UIElement;
+  children: string[];
+  childIndex: number;
+  childVersions: Array<[string, number]>;
+}
+
+function useElementSignatures(spec: Spec | null): Record<string, number> {
+  const entriesRef = useRef<Record<string, ElementSignatureEntry>>({});
+  const versionRef = useRef(0);
+  if (!spec) return {};
+
+  const previous = entriesRef.current;
+  const next: Record<string, ElementSignatureEntry> = {};
+  const signatures: Record<string, number> = {};
+  const visiting = new Set<string>();
+
+  for (const key of Object.keys(spec.elements)) {
+    if (signatures[key] !== undefined) continue;
+    const element = spec.elements[key];
+    if (!element) continue;
+    visiting.add(key);
+    const stack: ElementSignatureFrame[] = [
+      {
+        key,
+        element,
+        children: [
+          ...(element.children ?? []),
+          ...Object.values(element.slots ?? {}).flat(),
+        ],
+        childIndex: 0,
+        childVersions: [],
+      },
+    ];
+
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1]!;
+      const childKey = frame.children[frame.childIndex];
+      if (childKey !== undefined) {
+        const childVersion = signatures[childKey];
+        if (childVersion !== undefined) {
+          frame.childVersions.push([childKey, childVersion]);
+          frame.childIndex += 1;
+          continue;
+        }
+        const childElement = spec.elements[childKey];
+        if (!childElement || visiting.has(childKey)) {
+          frame.childVersions.push([childKey, -1]);
+          frame.childIndex += 1;
+          continue;
+        }
+        visiting.add(childKey);
+        stack.push({
+          key: childKey,
+          element: childElement,
+          children: [
+            ...(childElement.children ?? []),
+            ...Object.values(childElement.slots ?? {}).flat(),
+          ],
+          childIndex: 0,
+          childVersions: [],
+        });
+        continue;
+      }
+
+      const own = JSON.stringify([
+        frame.element,
+        Object.keys(frame.element.props),
+      ]);
+      const childVersions = JSON.stringify(frame.childVersions);
+      const prior = previous[frame.key];
+      const version =
+        prior?.own === own && prior.children === childVersions
+          ? prior.version
+          : ++versionRef.current;
+      visiting.delete(frame.key);
+      next[frame.key] = { own, children: childVersions, version };
+      signatures[frame.key] = version;
+      stack.pop();
+    }
+  }
+  entriesRef.current = next;
+  return signatures;
+}
+
+interface CatalogComponentBoundaryProps {
+  Component: ComponentRenderer;
+  signature: number | undefined;
+  execute: ReturnType<typeof useActions>["execute"];
+  actionContext: ReturnType<typeof useRepeatScope>;
+  functions: Record<string, ComputedFunction>;
+  directives: DirectiveRegistry | undefined;
+  element: UIElement;
+  slots?: Record<string, ReactNode>;
+  emit: (event: string) => void;
+  on: (event: string) => EventHandle;
+  bindings?: Record<string, string>;
+  loading?: boolean;
+  children?: ReactNode;
+}
+
+const CatalogComponentBoundary = React.memo(
+  function CatalogComponentBoundary({
+    Component,
+    element,
+    slots,
+    emit,
+    on,
+    bindings,
+    loading,
+    children,
+  }: CatalogComponentBoundaryProps) {
+    return (
+      <Component
+        element={element}
+        slots={slots}
+        emit={emit}
+        on={on}
+        bindings={bindings}
+        loading={loading}
+      >
+        {children}
+      </Component>
+    );
+  },
+  (previous, next) =>
+    previous.Component === next.Component &&
+    previous.signature === next.signature &&
+    previous.execute === next.execute &&
+    previous.actionContext?.item === next.actionContext?.item &&
+    previous.actionContext?.index === next.actionContext?.index &&
+    previous.actionContext?.basePath === next.actionContext?.basePath &&
+    previous.functions === next.functions &&
+    previous.directives === next.directives &&
+    previous.element.props === next.element.props &&
+    previous.bindings === next.bindings &&
+    previous.loading === next.loading,
+);
 
 /**
  * Subscribe to whether any devtools is mounted so the renderer can add a
@@ -204,13 +381,14 @@ function useDevtoolsActive(): boolean {
  * Element renderer component.
  * Memoized to prevent re-rendering all repeat children when state changes.
  */
-const ElementRenderer = React.memo(function ElementRenderer({
+function ReactiveElementRenderer({
   element,
   elementKey,
   spec,
   registry,
   loading,
   fallback,
+  signatures,
 }: ElementRendererProps) {
   const devtoolsActive = useDevtoolsActive();
   const repeatScope = useRepeatScope();
@@ -311,6 +489,10 @@ const ElementRenderer = React.memo(function ElementRenderer({
   const watchConfig = element.watch;
   const prevWatchValues = useRef<Record<string, unknown> | null>(null);
   const stableWatchRef = useRef<Record<string, unknown> | undefined>(undefined);
+  const stableBindingsRef = useRef<Record<string, string> | undefined>(
+    undefined,
+  );
+  const stableResolvedPropsRef = useRef<Record<string, unknown>>({});
 
   const watchedValues = useMemo(() => {
     if (!watchConfig) return undefined;
@@ -385,10 +567,16 @@ const ElementRenderer = React.memo(function ElementRenderer({
 
   // Resolve $bindState/$bindItem expressions → bindings map (prop name → state path)
   const rawProps = element.props as Record<string, unknown>;
-  const elementBindings = resolveBindings(rawProps, fullCtx);
+  const elementBindings = stabilizeRecord(
+    resolveBindings(rawProps, fullCtx),
+    stableBindingsRef,
+  );
 
   // Resolve dynamic prop expressions ($state, $item, $index, $bindState, $bindItem, $cond/$then/$else)
-  const resolvedProps = resolveElementProps(rawProps, fullCtx);
+  const resolvedProps = stabilizeRecord(
+    resolveElementProps(rawProps, fullCtx),
+    stableResolvedPropsRef,
+  );
 
   const resolvedElement =
     resolvedProps !== element.props
@@ -442,6 +630,7 @@ const ElementRenderer = React.memo(function ElementRenderer({
           registry={registry}
           loading={loading}
           fallback={fallback}
+          signatures={signatures}
         />
       );
     });
@@ -454,6 +643,7 @@ const ElementRenderer = React.memo(function ElementRenderer({
       loading={loading}
       fallback={fallback}
       itemFilter={repeatItemFilter}
+      signatures={signatures}
     />
   ) : resolvedElement.children ? (
     renderChildKeys(resolvedElement.children)
@@ -469,7 +659,13 @@ const ElementRenderer = React.memo(function ElementRenderer({
     : undefined;
 
   const rendered = (
-    <Component
+    <CatalogComponentBoundary
+      Component={Component}
+      signature={signatures[elementKey ?? ""]}
+      execute={execute}
+      actionContext={repeatScope}
+      functions={functions}
+      directives={directives}
       element={resolvedElement}
       slots={slots}
       emit={emit}
@@ -478,7 +674,7 @@ const ElementRenderer = React.memo(function ElementRenderer({
       loading={loading}
     >
       {children}
-    </Component>
+    </CatalogComponentBoundary>
   );
 
   // When devtools is mounted, wrap each element in a transparent span so the
@@ -494,11 +690,27 @@ const ElementRenderer = React.memo(function ElementRenderer({
     );
 
   return (
-    <ElementErrorBoundary elementType={resolvedElement.type}>
+    <ElementErrorBoundary
+      elementType={resolvedElement.type}
+      resetKey={signatures[elementKey ?? ""]}
+    >
       {tagged}
     </ElementErrorBoundary>
   );
-});
+}
+
+const ElementRenderer = React.memo(
+  function ElementRenderer(props: ElementRendererProps) {
+    return <ReactiveElementRenderer {...props} />;
+  },
+  (previous, next) =>
+    previous.elementKey === next.elementKey &&
+    previous.signatures[previous.elementKey ?? ""] ===
+      next.signatures[next.elementKey ?? ""] &&
+    previous.registry === next.registry &&
+    previous.loading === next.loading &&
+    previous.fallback === next.fallback,
+);
 
 // ---------------------------------------------------------------------------
 // RepeatChildren -- renders child elements once per item in a state array.
@@ -511,6 +723,7 @@ function RepeatChildren({
   registry,
   loading,
   fallback,
+  signatures,
   itemFilter,
 }: {
   element: UIElement;
@@ -518,6 +731,7 @@ function RepeatChildren({
   registry: ComponentRegistry;
   loading?: boolean;
   fallback?: ComponentRenderer;
+  signatures: Record<string, number>;
   itemFilter?: UIElement["visible"];
 }) {
   const { state } = useStateStore();
@@ -589,6 +803,7 @@ function RepeatChildren({
                   registry={registry}
                   loading={loading}
                   fallback={fallback}
+                  signatures={signatures}
                 />
               );
             })}
@@ -603,6 +818,7 @@ function RepeatChildren({
  * Main renderer component
  */
 export function Renderer({ spec, registry, loading, fallback }: RendererProps) {
+  const signatures = useElementSignatures(spec);
   if (!spec || !spec.root) {
     return null;
   }
@@ -620,6 +836,7 @@ export function Renderer({ spec, registry, loading, fallback }: RendererProps) {
       registry={registry}
       loading={loading}
       fallback={fallback}
+      signatures={signatures}
     />
   );
 }

--- a/packages/react/src/renderer.tsx
+++ b/packages/react/src/renderer.tsx
@@ -220,9 +220,92 @@ function stabilizeRecord<T extends Record<string, unknown> | undefined>(
   return value;
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function structurallyEqual(previous: unknown, next: unknown): boolean {
+  if (Object.is(previous, next)) return true;
+  const previousIsArray = Array.isArray(previous);
+  if (previousIsArray !== Array.isArray(next)) return false;
+  if (
+    !previousIsArray &&
+    (previous === null ||
+      next === null ||
+      typeof previous !== "object" ||
+      typeof next !== "object")
+  ) {
+    return false;
+  }
+
+  const previousRecord = previous as Record<string, unknown>;
+  const nextRecord = next as Record<string, unknown>;
+  const keys = Object.keys(nextRecord);
+  if (
+    (previousIsArray &&
+      (previous as unknown[]).length !== (next as unknown[]).length) ||
+    keys.length !== Object.keys(previousRecord).length
+  ) {
+    return false;
+  }
+  return keys.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(previousRecord, key) &&
+      structurallyEqual(previousRecord[key], nextRecord[key]),
+  );
+}
+
+function snapshotStructuralValue(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  const snapshot: Record<string, unknown> | unknown[] = Array.isArray(value)
+    ? new Array(value.length)
+    : {};
+  for (const key of Object.keys(value)) {
+    (snapshot as Record<string, unknown>)[key] = snapshotStructuralValue(
+      (value as Record<string, unknown>)[key],
+    );
+  }
+  return snapshot;
+}
+
+function shareResolvedValue(previous: unknown, next: unknown): unknown {
+  if (Object.is(previous, next)) return previous;
+  const previousIsArray = Array.isArray(previous);
+  if (previousIsArray !== Array.isArray(next)) return next;
+  if (!previousIsArray && (!isPlainRecord(previous) || !isPlainRecord(next))) {
+    return next;
+  }
+
+  // `next` can hold containers owned by the state model, directives, or
+  // computed functions, so share into a copy instead of writing into it.
+  const previousRecord = previous as Record<string, unknown>;
+  const nextRecord = next as Record<string, unknown>;
+  const keys = Object.keys(nextRecord);
+  const shared: Record<string, unknown> | unknown[] = previousIsArray
+    ? new Array((next as unknown[]).length)
+    : {};
+  let unchanged =
+    (!previousIsArray ||
+      (previous as unknown[]).length === (next as unknown[]).length) &&
+    keys.length === Object.keys(previousRecord).length;
+  for (const key of keys) {
+    let value = nextRecord[key];
+    if (Object.prototype.hasOwnProperty.call(previousRecord, key)) {
+      value = shareResolvedValue(previousRecord[key], value);
+      if (!Object.is(previousRecord[key], value)) unchanged = false;
+    } else {
+      unchanged = false;
+    }
+    (shared as Record<string, unknown>)[key] = value;
+  }
+  return unchanged ? previous : shared;
+}
+
 interface ElementSignatureEntry {
-  own: string;
-  children: string;
+  own: UIElement;
+  children: Array<[string, number]>;
   version: number;
 }
 
@@ -292,18 +375,19 @@ function useElementSignatures(spec: Spec | null): Record<string, number> {
         continue;
       }
 
-      const own = JSON.stringify([
-        frame.element,
-        Object.keys(frame.element.props ?? {}),
-      ]);
-      const childVersions = JSON.stringify(frame.childVersions);
       const prior = previous[frame.key];
       const version =
-        prior?.own === own && prior.children === childVersions
+        prior &&
+        structurallyEqual(prior.own, frame.element) &&
+        structurallyEqual(prior.children, frame.childVersions)
           ? prior.version
           : ++versionRef.current;
       visiting.delete(frame.key);
-      next[frame.key] = { own, children: childVersions, version };
+      next[frame.key] = {
+        own: snapshotStructuralValue(frame.element) as UIElement,
+        children: frame.childVersions,
+        version,
+      };
       signatures[frame.key] = version;
       stack.pop();
     }
@@ -576,10 +660,11 @@ function ReactiveElementRenderer({
   );
 
   // Resolve dynamic prop expressions ($state, $item, $index, $bindState, $bindItem, $cond/$then/$else)
-  const resolvedProps = stabilizeRecord(
+  const resolvedProps = shareResolvedValue(
+    stableResolvedPropsRef.current,
     resolveElementProps(rawProps, fullCtx),
-    stableResolvedPropsRef,
-  );
+  ) as Record<string, unknown>;
+  stableResolvedPropsRef.current = resolvedProps;
 
   const resolvedElement =
     resolvedProps !== element.props

--- a/packages/react/src/streaming-render.test.tsx
+++ b/packages/react/src/streaming-render.test.tsx
@@ -274,6 +274,60 @@ describe("streaming render stability", () => {
     expect(view.container.textContent).toBe("bar");
   });
 
+  it("recovers when props arrive after the element type", () => {
+    const parts: DataPart[] = [
+      {
+        type: "data-spec",
+        data: {
+          type: "patch",
+          patch: { op: "add", path: "/root", value: "value" },
+        },
+      },
+      {
+        type: "data-spec",
+        data: {
+          type: "patch",
+          patch: {
+            op: "add",
+            path: "/elements/value",
+            value: { type: "Value" },
+          },
+        },
+      },
+    ];
+    const registry: ComponentRegistry = {
+      Value: ({ element }) => (
+        <span>{String(element.props.label ?? "waiting")}</span>
+      ),
+    };
+    const incomplete = buildSpecFromParts(parts);
+    const view = render(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={incomplete} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("waiting");
+
+    parts.push({
+      type: "data-spec",
+      data: {
+        type: "patch",
+        patch: {
+          op: "add",
+          path: "/elements/value/props",
+          value: { label: "ready" },
+        },
+      },
+    });
+    const complete = buildSpecFromParts(parts);
+    view.rerender(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={complete} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("ready");
+  });
+
   it("keeps repeated event callbacks bound to the current item", async () => {
     let updateItem: (() => void) | undefined;
     const received: unknown[] = [];

--- a/packages/react/src/streaming-render.test.tsx
+++ b/packages/react/src/streaming-render.test.tsx
@@ -1,0 +1,635 @@
+import { act, render } from "@testing-library/react";
+import {
+  defineDirective,
+  resolvePropValue,
+  type Spec,
+} from "@json-render/core";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { buildSpecFromParts, type DataPart } from "./hooks";
+import { JSONUIProvider, Renderer, type ComponentRegistry } from "./renderer";
+import { useStateStore } from "./contexts/state";
+
+const ELEMENT_COUNT = 26;
+const PATCH_COUNT = 200;
+
+function makeSpec(): Spec {
+  const children = Array.from(
+    { length: ELEMENT_COUNT },
+    (_, index) => `metric-${index}`,
+  );
+  return {
+    root: "root",
+    state: Object.fromEntries(children.map((key, index) => [key, index])),
+    elements: {
+      root: { type: "Stack", props: {}, children },
+      ...Object.fromEntries(
+        children.map((key) => [
+          key,
+          {
+            type: "Metric",
+            props: { value: { $bindState: `/${key}` }, revision: 0 },
+          },
+        ]),
+      ),
+    },
+  };
+}
+
+function patchPart(revision: number): DataPart {
+  return {
+    type: "data-spec",
+    data: {
+      type: "patch",
+      patch: {
+        op: "replace",
+        path: "/elements/metric-0/props/revision",
+        value: revision,
+      },
+    },
+  };
+}
+
+describe("streaming render stability", () => {
+  it("does not execute untouched catalog components for each patch", async () => {
+    const parts: DataPart[] = [
+      { type: "data-spec", data: { type: "flat", spec: makeSpec() } },
+    ];
+    let stackRenders = 0;
+    let metricRenders = 0;
+    const registry: ComponentRegistry = {
+      Stack: ({ children }) => {
+        stackRenders += 1;
+        return <>{children}</>;
+      },
+      Metric: () => {
+        metricRenders += 1;
+        return null;
+      },
+    };
+    const initialSpec = buildSpecFromParts(parts);
+    const view = render(
+      <JSONUIProvider registry={registry} initialState={initialSpec?.state}>
+        <Renderer spec={initialSpec} registry={registry} />
+      </JSONUIProvider>,
+    );
+
+    for (let revision = 1; revision <= PATCH_COUNT; revision += 1) {
+      await act(async () => {
+        parts.push(patchPart(revision));
+        const spec = buildSpecFromParts(parts);
+        view.rerender(
+          <JSONUIProvider registry={registry} initialState={spec?.state}>
+            <Renderer spec={spec} registry={registry} />
+          </JSONUIProvider>,
+        );
+      });
+    }
+    expect(stackRenders).toBe(PATCH_COUNT + 1);
+    expect(metricRenders).toBe(ELEMENT_COUNT + PATCH_COUNT);
+    expect(initialSpec?.elements["metric-1"]?.props.revision).toBe(0);
+  });
+
+  it("does not execute untouched element renderers for each patch", async () => {
+    const parts: DataPart[] = [
+      { type: "data-spec", data: { type: "flat", spec: makeSpec() } },
+    ];
+    for (const [key, element] of Object.entries(parts[0]!.data.spec.elements)) {
+      if (key !== "root") element.props.probe = { $count: key };
+    }
+    let elementExecutions = 0;
+    const countDirective = defineDirective({
+      name: "$count",
+      resolve(value) {
+        elementExecutions += 1;
+        return value.$count;
+      },
+    });
+    const directives = [countDirective];
+    const registry: ComponentRegistry = {
+      Stack: ({ children }) => <>{children}</>,
+      Metric: () => null,
+    };
+    const initialSpec = buildSpecFromParts(parts);
+    const view = render(
+      <JSONUIProvider
+        registry={registry}
+        initialState={initialSpec?.state}
+        directives={directives}
+      >
+        <Renderer spec={initialSpec} registry={registry} />
+      </JSONUIProvider>,
+    );
+
+    for (let revision = 1; revision <= PATCH_COUNT; revision += 1) {
+      await act(async () => {
+        parts.push(patchPart(revision));
+        const spec = buildSpecFromParts(parts);
+        view.rerender(
+          <JSONUIProvider
+            registry={registry}
+            initialState={spec?.state}
+            directives={directives}
+          >
+            <Renderer spec={spec} registry={registry} />
+          </JSONUIProvider>,
+        );
+      });
+    }
+    expect(elementExecutions).toBe(ELEMENT_COUNT + PATCH_COUNT);
+  });
+
+  it("keeps binding identity stable across state writes", () => {
+    let writes = 0;
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    function WritingMetric({
+      bindings,
+    }: React.ComponentProps<ComponentRegistry[string]>) {
+      const { set } = useStateStore();
+      React.useEffect(() => {
+        writes += 1;
+        set("/metric-0", writes);
+      }, [bindings, set]);
+      return null;
+    }
+    const spec = makeSpec();
+    const registry: ComponentRegistry = {
+      Stack: ({ children }) => <>{children}</>,
+      Metric: WritingMetric,
+    };
+
+    render(
+      <JSONUIProvider registry={registry} initialState={spec.state}>
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    );
+    const output = error.mock.calls.flat().map(String).join("\n");
+    expect(output).not.toMatch(/Maximum update depth exceeded/);
+    expect(writes).toBe(ELEMENT_COUNT);
+    error.mockRestore();
+  });
+
+  it("preserves state context updates for catalog components", async () => {
+    let metricRenders = 0;
+    let write: (() => void) | undefined;
+    function Metric() {
+      metricRenders += 1;
+      const { set } = useStateStore();
+      write = () => set("/metric-0", 999);
+      return null;
+    }
+    const spec = makeSpec();
+    const registry: ComponentRegistry = {
+      Stack: ({ children }) => <>{children}</>,
+      Metric,
+    };
+    render(
+      <JSONUIProvider registry={registry} initialState={spec.state}>
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(metricRenders).toBe(ELEMENT_COUNT);
+    await act(async () => write?.());
+    expect(metricRenders).toBe(ELEMENT_COUNT * 2);
+  });
+
+  it("renders a child that becomes available in a later complete spec", () => {
+    const registry: ComponentRegistry = {
+      Stack: ({ children }) => <>{children}</>,
+      Metric: ({ element }) => <span>{String(element.props.revision)}</span>,
+    };
+    const initial: Spec = {
+      root: "root",
+      elements: {
+        root: { type: "Stack", props: {}, children: ["late"] },
+      },
+    };
+    const view = render(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={initial} registry={registry} loading />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("");
+    const complete: Spec = {
+      root: "root",
+      elements: {
+        root: { type: "Stack", props: {}, children: ["late"] },
+        late: { type: "Metric", props: { revision: 1 } },
+      },
+    };
+    view.rerender(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={complete} registry={registry} loading={false} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("1");
+  });
+
+  it("updates direct renderer consumers with fresh complete specs", () => {
+    const registry: ComponentRegistry = {
+      Stack: ({ children }) => <>{children}</>,
+      Metric: ({ element }) => <span>{String(element.props.revision)}</span>,
+    };
+    const first = makeSpec();
+    const view = render(
+      <JSONUIProvider registry={registry} initialState={first.state}>
+        <Renderer spec={first} registry={registry} />
+      </JSONUIProvider>,
+    );
+    const next = structuredClone(first);
+    next.elements["metric-0"]!.props.revision = 9;
+    view.rerender(
+      <JSONUIProvider registry={registry} initialState={next.state}>
+        <Renderer spec={next} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent?.startsWith("9")).toBe(true);
+  });
+
+  it("does not preserve stale prop keys with undefined values", () => {
+    const registry: ComponentRegistry = {
+      Value: ({ element }) => (
+        <span>{Object.keys(element.props).join(",")}</span>
+      ),
+    };
+    const first: Spec = {
+      root: "value",
+      elements: { value: { type: "Value", props: { foo: undefined } } },
+    };
+    const view = render(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={first} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("foo");
+    const second: Spec = {
+      root: "value",
+      elements: { value: { type: "Value", props: { bar: undefined } } },
+    };
+    view.rerender(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={second} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("bar");
+  });
+
+  it("keeps repeated event callbacks bound to the current item", async () => {
+    let updateItem: (() => void) | undefined;
+    const received: unknown[] = [];
+    function Controls() {
+      const { set } = useStateStore();
+      updateItem = () => set("/items/0", { id: "one", label: "updated" });
+      return null;
+    }
+    const spec: Spec = {
+      root: "list",
+      state: { items: [{ id: "one", label: "initial" }] },
+      elements: {
+        list: {
+          type: "List",
+          props: {},
+          repeat: { statePath: "/items", key: "id" },
+          children: ["button"],
+        },
+        button: {
+          type: "Button",
+          props: {},
+          on: {
+            press: {
+              action: "select",
+              params: {
+                label: {
+                  $computed: "itemLabel",
+                  args: { label: { $item: "label" } },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const registry: ComponentRegistry = {
+      List: ({ children }) => <>{children}</>,
+      Button: ({ emit }) => <button onClick={() => emit("press")}>pick</button>,
+    };
+    const view = render(
+      <JSONUIProvider
+        registry={registry}
+        initialState={spec.state}
+        functions={{ itemLabel: ({ label }) => label }}
+        handlers={{ select: ({ label }) => received.push(label) }}
+      >
+        <Controls />
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    );
+
+    await act(async () => updateItem?.());
+    await act(async () => view.getByRole("button").click());
+    expect(received).toEqual(["updated"]);
+  });
+
+  it("refreshes resolved props when functions and directives change", () => {
+    const spec: Spec = {
+      root: "value",
+      elements: {
+        value: {
+          type: "Value",
+          props: {
+            computed: { $computed: "label" },
+            directed: { $prefix: "value" },
+          },
+        },
+      },
+    };
+    const registry: ComponentRegistry = {
+      Value: ({ element }) => (
+        <span>{`${element.props.computed}:${element.props.directed}`}</span>
+      ),
+    };
+    const firstDirective = defineDirective({
+      name: "$prefix",
+      resolve(value, ctx) {
+        return `first-${resolvePropValue(value.$prefix, ctx)}`;
+      },
+    });
+    const secondDirective = defineDirective({
+      name: "$prefix",
+      resolve(value, ctx) {
+        return `second-${resolvePropValue(value.$prefix, ctx)}`;
+      },
+    });
+    const view = render(
+      <JSONUIProvider
+        registry={registry}
+        functions={{ label: () => "first" }}
+        directives={[firstDirective]}
+      >
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("first:first-value");
+
+    view.rerender(
+      <JSONUIProvider
+        registry={registry}
+        functions={{ label: () => "second" }}
+        directives={[secondDirective]}
+      >
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("second:second-value");
+  });
+
+  it("keeps event callbacks fresh when functions and directives change", async () => {
+    const received: unknown[] = [];
+    const spec: Spec = {
+      root: "button",
+      elements: {
+        button: {
+          type: "Button",
+          props: {},
+          on: {
+            press: {
+              action: "select",
+              params: {
+                computed: { $computed: "label" },
+                directed: { $prefix: "value" },
+              },
+            },
+          },
+        },
+      },
+    };
+    const registry: ComponentRegistry = {
+      Button: ({ emit }) => <button onClick={() => emit("press")}>pick</button>,
+    };
+    const firstDirective = defineDirective({
+      name: "$prefix",
+      resolve(value) {
+        return `first-${String(value.$prefix)}`;
+      },
+    });
+    const secondDirective = defineDirective({
+      name: "$prefix",
+      resolve(value) {
+        return `second-${String(value.$prefix)}`;
+      },
+    });
+    const handlers = {
+      select: (params: Record<string, unknown>) => received.push(params),
+    };
+    const view = render(
+      <JSONUIProvider
+        registry={registry}
+        functions={{ label: () => "first" }}
+        directives={[firstDirective]}
+        handlers={handlers}
+      >
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    );
+
+    view.rerender(
+      <JSONUIProvider
+        registry={registry}
+        functions={{ label: () => "second" }}
+        directives={[secondDirective]}
+        handlers={handlers}
+      >
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    );
+    await act(async () => view.getByRole("button").click());
+    expect(received).toEqual([
+      { computed: "second", directed: "second-value" },
+    ]);
+  });
+
+  it("supports non-serializable resolved state and repeat items", () => {
+    const cyclic: Record<string, unknown> = { value: 1 };
+    cyclic.self = cyclic;
+    const spec: Spec = {
+      root: "list",
+      state: { cyclic, items: [{ id: 1n }] },
+      elements: {
+        list: {
+          type: "List",
+          props: { value: { $state: "/cyclic" } },
+          repeat: { statePath: "/items" },
+          children: ["item"],
+        },
+        item: { type: "Item", props: { id: { $item: "id" } } },
+      },
+    };
+    const registry: ComponentRegistry = {
+      List: ({ children }) => <>{children}</>,
+      Item: ({ element }) => <span>{String(element.props.id)}</span>,
+    };
+
+    const view = render(
+      <JSONUIProvider registry={registry} initialState={spec.state}>
+        <Renderer spec={spec} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("1");
+  });
+
+  it("propagates shared-child updates through a DAG", () => {
+    const registry: ComponentRegistry = {
+      Stack: ({ children }) => <>{children}</>,
+      Value: ({ element }) => <span>{String(element.props.revision)}</span>,
+    };
+    const first: Spec = {
+      root: "root",
+      elements: {
+        root: { type: "Stack", props: {}, children: ["left", "right"] },
+        left: { type: "Stack", props: {}, children: ["shared"] },
+        right: { type: "Stack", props: {}, children: ["shared"] },
+        shared: { type: "Value", props: { revision: 1 } },
+      },
+    };
+    const view = render(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={first} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("11");
+    const second = structuredClone(first);
+    second.elements.shared!.props.revision = 2;
+    view.rerender(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={second} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("22");
+  });
+
+  it("terminates signature computation for cyclic element graphs", () => {
+    const spec: Spec = {
+      root: "",
+      elements: {
+        first: { type: "Node", props: {}, children: ["second"] },
+        second: { type: "Node", props: {}, children: ["first"] },
+      },
+    };
+    expect(() =>
+      render(<Renderer spec={spec} registry={{ Node: () => null }} />),
+    ).not.toThrow();
+  });
+
+  it("stops a watch action chain when its element unmounts", async () => {
+    let setValue: (() => void) | undefined;
+    let release: (() => void) | undefined;
+    const firstAction = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const secondAction = vi.fn();
+    function Controls() {
+      const { set } = useStateStore();
+      setValue = () => set("/value", "changed");
+      return null;
+    }
+    const registry: ComponentRegistry = {
+      Stack: ({ children }) => <>{children}</>,
+      Watcher: () => null,
+    };
+    const first: Spec = {
+      root: "root",
+      state: { value: "initial" },
+      elements: {
+        root: { type: "Stack", props: {}, children: ["watcher"] },
+        watcher: {
+          type: "Watcher",
+          props: {},
+          watch: {
+            "/value": [{ action: "first" }, { action: "second" }],
+          },
+        },
+      },
+    };
+    const handlers = { first: firstAction, second: secondAction };
+    const view = render(
+      <JSONUIProvider
+        registry={registry}
+        initialState={first.state}
+        handlers={handlers}
+      >
+        <Controls />
+        <Renderer spec={first} registry={registry} />
+      </JSONUIProvider>,
+    );
+    await act(async () => setValue?.());
+    expect(firstAction).toHaveBeenCalledTimes(1);
+    const second: Spec = {
+      ...first,
+      elements: {
+        ...first.elements,
+        root: { type: "Stack", props: {}, children: [] },
+      },
+    };
+    view.rerender(
+      <JSONUIProvider
+        registry={registry}
+        initialState={first.state}
+        handlers={handlers}
+      >
+        <Controls />
+        <Renderer spec={second} registry={registry} />
+      </JSONUIProvider>,
+    );
+    await act(async () => release?.());
+    expect(secondAction).not.toHaveBeenCalled();
+  });
+
+  it("recovers a catalog component after a corrective patch", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const registry: ComponentRegistry = {
+      Value: ({ element }) => {
+        if (element.props.revision === 0) throw new Error("incomplete");
+        return <span>{String(element.props.revision)}</span>;
+      },
+    };
+    const first: Spec = {
+      root: "value",
+      elements: { value: { type: "Value", props: { revision: 0 } } },
+    };
+    const view = render(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={first} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("");
+    const second: Spec = {
+      root: "value",
+      elements: { value: { type: "Value", props: { revision: 1 } } },
+    };
+    view.rerender(
+      <JSONUIProvider registry={registry}>
+        <Renderer spec={second} registry={registry} />
+      </JSONUIProvider>,
+    );
+    expect(view.container.textContent).toBe("1");
+    error.mockRestore();
+  });
+
+  it("computes signatures for deep element graphs without recursion", () => {
+    const elements: Spec["elements"] = {};
+    for (let index = 0; index < 12_000; index += 1) {
+      elements[`node-${index}`] = {
+        type: "Node",
+        props: {},
+        children: index === 11_999 ? [] : [`node-${index + 1}`],
+      };
+    }
+    const spec: Spec = { root: "", elements };
+    expect(() =>
+      render(<Renderer spec={spec} registry={{ Node: () => null }} />),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #311.

Append-paced streaming rebuilt the complete spec for every patch. Because each `ElementRenderer` received the new spec reference, unchanged elements still executed on every patch. Fresh `bindings` and resolved-props wrappers could then turn consumer effects into a `Maximum update depth exceeded` loop.

This change:

- derives iterative bottom-up versions for elements and their structural descendants
- skips unchanged internal element renderers before their hooks execute
- memoizes catalog component execution across unchanged observable inputs
- stabilizes resolved props and bindings with key-aware shallow equality
- resets an element error boundary when a corrective streamed version arrives
- keeps the validation-functions default stable

Public spec, streaming, renderer, and binding contracts remain unchanged.

## Evidence

On a 26-element workload with 200 separately committed patches touching one element:

- element/catalog executions: 5,226 before, 226 after
- untouched leaf executions: 5,025 before, 0 after
- binding-write reproduction: update-depth loop before, 26 bounded writes after

The regression matrix covers direct complete specs, later children, state updates, repeat callback freshness, functions and directives, shared-child DAGs, cyclic graphs, 12,000-node depth, watch cleanup after unmount, error recovery, cyclic runtime state, and `BigInt` values.

## Verification

- `pnpm test`: 1,085/1,085
- `pnpm type-check`: 59/59
- `pnpm lint`: 14/14
- focused regression: 16/16, repeated five times
- force-red mutations for renderer bailout, key ownership, bindings, callbacks, DAG invalidation, deep traversal, watch cleanup, and recovery
- independent Gemini 3.7 Flash review: final `PASS`
- Review Gate on exact signed SHA `476e27a`: pass

## Remaining gap

Chrome heap retention and Fiber collection after forced GC were not measured locally. The tests directly prove removal of the repeated React work and update loop, but do not claim a browser heap profile.
