### PR TITLE
fix(core): align DynamicValueSchema with resolveActionParam's runtime contract

### DIFF
--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -17,6 +17,52 @@ import {
   SPEC_DATA_PART_TYPE,
 } from "./types";
 import type { Spec, SpecStreamLine, StreamChunk } from "./types";
+import { DynamicValueSchema } from "./types";
+import { resolveActionParam } from "./props";
+import type { PropResolutionContext } from "./props";
+
+describe("DynamicValueSchema matches resolveActionParam's runtime contract", () => {
+  const ctx: PropResolutionContext = {
+    stateModel: { form: { text: "hi" } },
+    repeatBasePath: "/todos/2",
+    repeatIndex: 2,
+  } as PropResolutionContext;
+
+  const shapes: [string, unknown][] = [
+    ["string literal", "hello"],
+    ["number literal", 42],
+    ["boolean literal", true],
+    ["null", null],
+    ["$state expression", { $state: "/form/text" }],
+    ["$item expression", { $item: "field" }],
+    ["$index expression", { $index: true }],
+    ["array of literals", ["a", "b"]],
+    ["array of expressions", [{ $state: "/form/text" }, { $index: true }]],
+    [
+      "object with nested expression values",
+      { id: { $state: "/form/text" }, label: "static" },
+    ],
+  ];
+
+  it.each(shapes)("accepts and resolves %s", (_name, value) => {
+    expect(DynamicValueSchema.safeParse(value).success).toBe(true);
+    // The runtime resolver must not throw on the same shape.
+    expect(() => resolveActionParam(value, ctx)).not.toThrow();
+  });
+
+  it("resolves the widened shapes the way the runtime documents them", () => {
+    expect(resolveActionParam({ $index: true }, ctx)).toBe(2);
+    expect(resolveActionParam(["a", "b"], ctx)).toEqual(["a", "b"]);
+    expect(resolveActionParam({ id: { $state: "/form/text" } }, ctx)).toEqual({
+      id: "hi",
+    });
+  });
+
+  it("rejects values outside the contract", () => {
+    expect(DynamicValueSchema.safeParse(undefined).success).toBe(false);
+    expect(DynamicValueSchema.safeParse(() => {}).success).toBe(false);
+  });
+});
 
 describe("getByPath", () => {
   it("gets nested values with JSON pointer paths", () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,13 +26,21 @@ export type DynamicBoolean = DynamicValue<boolean>;
 
 /**
  * Zod schema for dynamic values
+ *
+ * Mirrors what `resolveActionParam` (and `resolvePropValue` underneath it)
+ * accepts at runtime: literals, `$state` / `$item` / `$index` expressions,
+ * arrays, and plain objects whose values are themselves dynamic values.
  */
-export const DynamicValueSchema = z.union([
+export const DynamicValueSchema: z.ZodType<DynamicValue> = z.union([
   z.string(),
   z.number(),
   z.boolean(),
   z.null(),
   z.object({ $state: z.string() }),
+  z.object({ $item: z.string() }),
+  z.object({ $index: z.literal(true) }),
+  z.lazy(() => z.array(DynamicValueSchema)),
+  z.lazy(() => z.record(z.string(), DynamicValueSchema)),
 ]);
 
 export const DynamicStringSchema = z.union([


### PR DESCRIPTION
## Summary

`DynamicValueSchema` rejects shapes that `resolveActionParam` resolves correctly at runtime, producing false positives for tools that schema-validate emitted specs against `ActionBindingSchema`:

```ts
resolveActionParam({ $index: true }, ctx);                   // → 2
resolveActionParam(["a", "b"], ctx);                         // → ["a", "b"]
resolveActionParam({ id: { $state: "/form/text" } }, ctx);   // → { id: "hi" }

DynamicValueSchema.safeParse({ $index: true }).success;       // false
DynamicValueSchema.safeParse(["a", "b"]).success;             // false
DynamicValueSchema.safeParse({ id: { $state: "/x" } }).success; // false
```

All three shapes are documented API (the schema rules shipped in `packages/react/src/schema.ts` tell the model to use `{ "$item": "field" }`` and `{ "$index": true }`` inside repeated children, and the runtime recursively resolves arrays and plain-object values via `resolvePropValue`).

## Changes

Widen the union in `packages/core/src/types.ts`:

- `{ $item: string }` — resolves to an absolute state path in action params
- `{ $index: true }` — resolves to the current repeat index
- arrays of dynamic values (recursive)
- records whose values are dynamic values (recursive), mirroring the runtime's plain-object recursion

The expression object arms stay strict, so a malformed `{ $state: 123 }` still fails its dedicated arm — it only passes via the record arm, exactly matching the runtime, which treats it as a literal passthrough object.

## Tests

Added a parity block to `packages/core/src/types.test.ts` that runs each widened shape through **both** `DynamicValueSchema.safeParse` and `resolveActionParam`, pinning schema/runtime agreement:

```
pnpm vitest run packages/core/src
Test Files  12 passed (12)
     Tests  511 passed (511)
```

Fixes #296