### PR TITLE
docs: link community Angular renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ function Dashboard({ spec }) {
 | `@json-render/xstate`       | XState Store (atom) adapter for `StateStore`                           |
 | `@json-render/mcp`          | MCP Apps integration for Claude, ChatGPT, Cursor, VS Code              |
 | `@json-render/yaml`         | YAML wire format with streaming parser, edit modes, AI SDK transform   |
+| [`ngx-json-render`](https://github.com/shteynu/ngx-json-render) | Community Angular renderer built on `@json-render/core` (signals-based, Angular ≥21) |
 
 ## Renderers
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ function Dashboard({ spec }) {
 | `@json-render/xstate`       | XState Store (atom) adapter for `StateStore`                           |
 | `@json-render/mcp`          | MCP Apps integration for Claude, ChatGPT, Cursor, VS Code              |
 | `@json-render/yaml`         | YAML wire format with streaming parser, edit modes, AI SDK transform   |
-| [`ngx-json-render`](https://github.com/shteynu/ngx-json-render) | Community Angular renderer built on `@json-render/core` (signals-based, Angular ≥21) |
+| [`ngx-json-render`](https://github.com/shteynu/ngx-json-render) | Community Angular renderer built on `@json-render/core` (signals-based, Angular ≥20) |
 
 ## Renderers
 


### PR DESCRIPTION
Adds one row to the Packages table pointing to [ngx-json-render](https://github.com/shteynu/ngx-json-render) — a community Angular renderer built on `@json-render/core` ^0.20.

It implements the baseline renderer contract at parity with the official renderers (prop expressions incl. `$bindState`/`$cond`/`$template`/custom directives, visibility, repeat scopes, slots, actions with confirm flows, watch, validation, SpecStream patch streaming), built on Angular signals — zoneless-friendly, Angular ≥ 20. There is a companion catalog, [`ngx-json-render-material`](https://www.npmjs.com/package/ngx-json-render-material), with 28 Angular Material components, in the spirit of `@json-render/shadcn`. Live demo: https://shteynu.github.io/ngx-json-render/

Context: #244 has been open since March and #310 was closed by its author, so this ships as a standalone package for now. Happy to adapt it into `packages/angular` here if you'd take Angular support upstream — the code is structured for exactly that.
