### PR TITLE
fix(devtools): resolve ts7006 implicit-any bug

### DIFF
--- a/packages/devtools-react/src/index.tsx
+++ b/packages/devtools-react/src/index.tsx
@@ -272,7 +272,7 @@ export function JsonRenderDevtools(props: JsonRenderDevtoolsProps) {
     handleRef.current = panel;
 
     // Highlight in the host DOM as the selection changes.
-    const unsubSelection = selection.subscribe((key) => {
+    const unsubSelection = selection.subscribe((key: unknown) => {
       if (key) highlightElement(key);
     });
 

--- a/packages/devtools-solid/src/index.tsx
+++ b/packages/devtools-solid/src/index.tsx
@@ -141,7 +141,7 @@ export function JsonRenderDevtools(props: JsonRenderDevtoolsProps) {
       reserveSpace: props.reserveSpace,
       allowDockToggle: props.allowDockToggle,
     });
-    unsubSelection = selection.subscribe((key) => {
+    unsubSelection = selection.subscribe((key: unknown) => {
       if (key) highlightElement(key);
     });
     releaseActive = markDevtoolsActive();


### PR DESCRIPTION
# Summary
This PR fixes TypeScript strict‑mode errors (`TS7006: Parameter 'key' implicitly has an 'any' type`) in the internal devtools packages by explicitly typing the selection.subscribe callback parameter as unknown. The issue appeared in both the React and Solid devtools implementations.

## Changes

### React_devtools_fix  
Updated `unsubSelection = selection.subscribe((key) => { ... })` to
`unsubSelection = selection.subscribe((key: unknown) => { ... })`  
in **packages/devtools-react/src/index.tsx**.

### Solid_devtools_fix  
Applied the same fix in **packages/devtools-solid/src/index.tsx** for consistency.

## Why this matters
Each item begins with a Guided Link.

### TS_strict_mode  
TypeScript’s strict mode flags untyped callback parameters as implicit any, which breaks builds and reduces type safety.

### Internal_consistency  
Both devtools implementations now use the same safe typing strategy, preventing future strict‑mode regressions.

## Zero_runtime_change  
This PR only affects type annotations. No runtime behavior or public API surface is changed.

## Scope
This PR is strictly internal cleanup.
It does not modify logic, behavior, or user‑facing features.